### PR TITLE
Restore k8s chart and add sources env var to build process

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -7,6 +7,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  VITE_KG_SOURCES_YAML: "https://raw.githubusercontent.com/frink-okn/frink-landing-zone/refs/heads/main/docs/registry/kgs.yaml"
 
 jobs:
 
@@ -45,6 +46,8 @@ jobs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        build-args: |
+          VITE_KG_SOURCES_YAML=${{ env.VITE_KG_SOURCES_YAML }}
 
     - name: Generate artifact attestation
       uses: actions/attest-build-provenance@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ COPY package.json package-lock.json ./
 RUN npm ci
 
 FROM base AS builder
+ARG VITE_KG_SOURCES_YAML
+ENV VITE_KG_SOURCES_YAML=${VITE_KG_SOURCES_YAML}
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -1,0 +1,5 @@
+name: frink-ui
+apiVersion: v2
+version: 1.0.0
+type: application
+description: Frink query UI webapp.

--- a/kubernetes/templates/_labels.tpl
+++ b/kubernetes/templates/_labels.tpl
@@ -1,0 +1,12 @@
+# common labels
+{{- define "labels" -}}
+{{ include "selectorLabels" . }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+# selector labels
+{{- define "selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/kubernetes/templates/deployment.yaml
+++ b/kubernetes/templates/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    {{- include "labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ printf "%s:%s" .Values.image.repository .Values.image.tag }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: 30 
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 15

--- a/kubernetes/templates/ingress.yaml
+++ b/kubernetes/templates/ingress.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Chart.Name }}
+  annotations:
+    # This line will automatically generate a Let's Encrypt TLS certificate which will be stored in the secretName below. See https://cert-manager.io/docs/usage/ingress/
+    # This only works for DNS names in public zones like *.renci.org or *.apps.renci.org. See https://wiki.renci.org/index.php/Kubernetes_Cloud/Let%27s_Encrypt_Migration
+    cert-manager.io/cluster-issuer: letsencrypt
+
+    {{ if .Values.ingress.public }}
+    nginx.ingress.kubernetes.io/whitelist-source-range: "0.0.0.0/0,::/0"
+    {{ end }}
+  
+spec:
+  {{ if .Values.ingress.tls }}
+  tls:
+  - hosts:
+      - {{ .Values.ingress.host }}
+    secretName: {{ .Values.ingress.host }}-tls
+  {{ end }}
+  rules:
+  - host: {{ .Values.ingress.host }}
+    http:
+      paths:
+      - path: {{ .Values.ingress.path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Chart.Name }}
+            port:
+              number: {{ .Values.service.port }}

--- a/kubernetes/templates/service.yaml
+++ b/kubernetes/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    {{- include "labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -1,0 +1,23 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/frink-okn/frink-query-ui
+  tag: latest
+
+resources:
+  limits:
+    cpu: 250m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  host: frink.apps.renci.org
+  path: /
+  tls: true
+  public: true


### PR DESCRIPTION
@balhoff 

We should test both parts of this before we merge:

1. create a new release on this branch `update/restore-chart` to ensure the environment variable is correctly embedded in the build process. If it doesn't work, going to the site will display a blank page and an error in the browser console.
2. make sure the deployment chart + Dockerfile still works with the new site.

I'll go ahead and look at 1, I don't think I have access to the namespace where the ui is deployed, so you may have to try that