### PR TITLE
Fix Github Pages action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,8 +30,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Ensure GitHub sites base path is used
-        run: mv vite.config.gh-deploy.ts vite.config.ts
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -39,6 +37,8 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
+      - name: Ensure GitHub sites base path is used
+        run: export BASE_URL = "/frink-query-ui/"
       - name: Build
         run: npm run build
       - name: Setup Pages

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Ensure GitHub sites base path is used
-        run: export BASE_URL = "/frink-query-ui/"
+        run: export BASE_URL = "/${{ github.event.repository.name }}/"
       - name: Build
         run: npm run build
       - name: Setup Pages

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,4 +23,5 @@ export default defineConfig({
       }
     }),
   ],
+  base: process.env.BASE_URL,
 })


### PR DESCRIPTION
Regression from #60. Previous implementation used a separate `vite.config.gh-deploy.ts` file. This version looks for an environment variable called `BASE_URL`. Vite will use it if present, otherwise it uses the default base url. We set this in the Github workflow dynamically based on the repo name.

Closes #74 