### PR TITLE
make router use basepath, if available.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,7 +39,7 @@ jobs:
         run: npm ci
       - name: Build
         run: >
-          BASE_URL="/${{ github.event.repository.name }}/"
+          VITE_BASE_URL="/${{ github.event.repository.name }}/"
           VITE_GH_REPO="frink-okn/okn-registry"
           VITE_GH_SOURCES="/docs/registry/kgs.yaml"
           VITE_GH_EXAMPLES_DIRECTORY="/docs/registry/queries"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -43,7 +43,8 @@ const router = createRouter({
   routeTree,
   context: {
     queryClient,
-  }
+  },
+  basepath: import.meta.env.VITE_BASE_URL,
 });
 
 // Register all Community features

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,6 +5,7 @@ interface ImportMetaEnv {
   readonly VITE_GH_REPO: string;
   readonly VITE_GH_SOURCES: string;
   readonly VITE_GH_EXAMPLES_DIRECTORY: string;
+  readonly VITE_TANSTACK_BASE_URL?: string;
 }
 
 interface ImportMeta {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 
@@ -7,21 +7,25 @@ const ReactCompilerConfig = {
 }
 
 // https://vite.dev/config/
-export default defineConfig({
-  resolve: {
-    alias: {
-      '@mui/material': '@mui/joy'
-    }
-  },
-  plugins: [
-    TanStackRouterVite({ autoCodeSplitting: true }),
-    react({
-      babel: {
-        plugins: [
-          ["babel-plugin-react-compiler", ReactCompilerConfig],
-        ]
+export default defineConfig(({ mode }) => {
+  process.env = { ...process.env, ...loadEnv(mode, process.cwd(), '') }
+  
+  return {
+    resolve: {
+      alias: {
+        '@mui/material': '@mui/joy'
       }
-    }),
-  ],
-  base: process.env.BASE_URL,
+    },
+    plugins: [
+      TanStackRouterVite({ autoCodeSplitting: true }),
+      react({
+        babel: {
+          plugins: [
+            ["babel-plugin-react-compiler", ReactCompilerConfig],
+          ]
+        }
+      }),
+    ],
+    base: process.env.VITE_BASE_URL,
+  }
 })


### PR DESCRIPTION
this requires allowing this environment variable in the client bundle. To use the client env variables in the vite config we use code from this stack overflow answer to combine them into the process.env object:

https://stackoverflow.com/questions/66389043/how-can-i-use-vite-env-variables-in-vite-config-js