### PR TITLE
Settings option to invalidate example queries

### DIFF
--- a/src/context/savedQueries.tsx
+++ b/src/context/savedQueries.tsx
@@ -18,7 +18,7 @@ export const useSavedQueriesContext = () => {
   return context;
 };
 
-type SavedQuery = {
+export type SavedQuery = {
   title: string;
   sources: string[];
   query: string;

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -1,10 +1,59 @@
+import { Button, styled } from "@mui/joy";
+import { useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
+import { useLocalStorage } from "@uidotdev/usehooks";
+import type { SavedQuery } from "../context/savedQueries";
 import { PageWrapper } from "../ui/PageWrapper";
+import { SettingLine } from "../ui/SettingLine";
 
 export const Route = createFileRoute("/settings")({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  return <PageWrapper title="Settings">Settings</PageWrapper>;
+  const queryClient = useQueryClient();
+  const [, setSavedQueries] = useLocalStorage<SavedQuery[]>("saved-queries");
+
+  const invalidateCachedExamples = () => {
+    queryClient.invalidateQueries({ queryKey: ["examples"] });
+  };
+
+  const clearSavedQueries = () => {
+    setSavedQueries([]);
+  };
+
+  return (
+    <PageWrapper title="Settings">
+      <SettingsWrapper>
+        <SettingLine
+          settingName="Delete all saved queries"
+          settingDescription="This will delete all saved queries from the local storage. This action cannot be undone."
+        >
+          <Button color="danger" variant="soft" onClick={clearSavedQueries}>
+            Delete
+          </Button>
+        </SettingLine>
+
+        <SettingLine
+          settingName="Invalidate example queries cache"
+          settingDescription="Force a refresh of the cached example queries to fetch the latest data from the server. Normally, examples are cached for 24 hours."
+        >
+          <Button
+            color="danger"
+            variant="soft"
+            onClick={invalidateCachedExamples}
+          >
+            Refresh
+          </Button>
+        </SettingLine>
+      </SettingsWrapper>
+    </PageWrapper>
+  );
 }
+
+const SettingsWrapper = styled("div")`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  margin: 1rem 0;
+`;

--- a/src/ui/SettingLine.tsx
+++ b/src/ui/SettingLine.tsx
@@ -1,0 +1,51 @@
+import { styled } from "@mui/joy";
+
+interface SettingLineProps {
+  children?: React.ReactNode;
+  settingName: string;
+  settingDescription?: string;
+}
+
+export function SettingLine({
+  children,
+  settingName,
+  settingDescription,
+}: SettingLineProps) {
+  return (
+    <SettingLineWrapper>
+      <div>
+        <h3>{settingName}</h3>
+        {settingDescription && <p>{settingDescription}</p>}
+      </div>
+      {children}
+    </SettingLineWrapper>
+  );
+}
+
+const SettingLineWrapper = styled("div")`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+
+  border: 1px solid var(--p-slate-200);
+  border-radius: 8px;
+  padding: 1rem;
+
+  & div {
+    display: flex;
+    flex-direction: column;
+
+    & h3 {
+      margin: 0;
+      color: var(--p-slate-600);
+      font-size: 1rem;
+      font-weight: 600;
+      line-height: 1.5;
+    }
+
+    & p {
+      margin: 0;
+    }
+  }
+`;


### PR DESCRIPTION
This adds a button to the settings to manually invalidate the example queries cache so it will immediately request the fresh data. This PR also adds back the "delete all saved queries" functionality from the Vue version.

![image](https://github.com/user-attachments/assets/4dfcd8cf-1754-440a-a3ac-2cd64ee6753b)
