### PR TITLE
Example queries folder view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "js-yaml": "^4.1.0",
         "rdf-data-factory": "^2.0.2",
         "react": "19.0.0",
+        "react-aria-components": "^1.10.1",
         "react-dom": "19.0.0",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^2.1.7",
@@ -6129,6 +6130,57 @@
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
       "license": "MIT"
     },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
+      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.1",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
+      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/icu-skeleton-parser": "1.8.14",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
+      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
+      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "0.2.36",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
@@ -6218,6 +6270,43 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.2.tgz",
+      "integrity": "sha512-/wENk7CbvLbkUvX1tu0mwq49CVkkWpkXubGel6birjRPyo6uQ4nQpnq5xZu823zRCwwn82zgHrvgF1vZyvmVgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/message": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.8.tgz",
+      "integrity": "sha512-Rwk3j/TlYZhn3HQ6PyXUV0XP9Uv42jqZGNegt0BXlxjE6G3+LwHjbQZAGHhCnCPdaA6Tvd3ma/7QzLlLkJxAWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "intl-messageformat": "^10.1.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.3.tgz",
+      "integrity": "sha512-p+Zh1sb6EfrfVaS86jlHGQ9HA66fJhV9x5LiE5vCbZtXEHAuhcmUZUdZ4WrFpUBfNalr2OkAJI5AcKEQF+Lebw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.7.tgz",
+      "integrity": "sha512-D4OHBjrinH+PFZPvfCXvG28n2LSykWcJ7GIioQL+ok0LON15SdfoUssoHzzOUmVZLbRoREsQXVzA6r8JKsbP6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@jeswr/prefixcc": {
@@ -6795,6 +6884,1802 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@react-aria/autocomplete": {
+      "version": "3.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/autocomplete/-/autocomplete-3.0.0-beta.5.tgz",
+      "integrity": "sha512-zYiVeKGYHStpBXS0mf51k14xkVunU/dFqxumfYXDiiyknxIDE4L1kN7XKo16nus3TkTmJtqBHJrWmzCfNkRd9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/combobox": "^3.12.5",
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/listbox": "^3.14.6",
+        "@react-aria/searchfield": "^3.8.6",
+        "@react-aria/textfield": "^3.17.5",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/autocomplete": "3.0.0-beta.2",
+        "@react-stately/combobox": "^3.10.6",
+        "@react-types/autocomplete": "3.0.0-alpha.32",
+        "@react-types/button": "^3.12.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/breadcrumbs": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@react-aria/breadcrumbs/-/breadcrumbs-3.5.26.tgz",
+      "integrity": "sha512-jybk2jy3m9KNmTpzJu87C0nkcMcGbZIyotgK1s8st8aUE2aJlxPZrvGuJTO8GUFZn9TKnCg3JjBC8qS9sizKQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/link": "^3.8.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/breadcrumbs": "^3.7.14",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/button": {
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.13.3.tgz",
+      "integrity": "sha512-Xn7eTssaefNPUydogI1qDf7qQWPmb+hGoS1QiCNBodPlRpVDXxlZSIhOqQFnLWHv5+z5UL+vu+joqlSPYHqOFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/toolbar": "3.0.0-beta.18",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/toggle": "^3.8.5",
+        "@react-types/button": "^3.12.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/calendar": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/calendar/-/calendar-3.8.3.tgz",
+      "integrity": "sha512-1TAZADcWbfznXzo4oJEqFgX4IE1chZjWsTSJDWr03UEx3XqIJI8GXm+ylOQUiN4j8xqZ7tl4yNuuslKkzoSjMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/live-announcer": "^3.4.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/calendar": "^3.8.2",
+        "@react-types/button": "^3.12.2",
+        "@react-types/calendar": "^3.7.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/checkbox": {
+      "version": "3.15.7",
+      "resolved": "https://registry.npmjs.org/@react-aria/checkbox/-/checkbox-3.15.7.tgz",
+      "integrity": "sha512-L64van+K2ZEmCpx/KeZGHoxdxQvVHgfusFRFYZbh3e7YEtDcShvUrTDVKmZkINqnmuhGTDolFDQq+E8fWEpcRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/form": "^3.0.18",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/label": "^3.7.19",
+        "@react-aria/toggle": "^3.11.5",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/checkbox": "^3.6.15",
+        "@react-stately/form": "^3.1.5",
+        "@react-stately/toggle": "^3.8.5",
+        "@react-types/checkbox": "^3.9.5",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/collections": {
+      "version": "3.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/collections/-/collections-3.0.0-rc.3.tgz",
+      "integrity": "sha512-TX6aAzK/FMTvT78LNdSSacKYDnfBWyW5WzxfoQiu/K/kbZVrYSrQaXFrGjkwGEhgmU0O1S4mupANMEgmgI3wlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/ssr": "^3.9.9",
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/color": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@react-aria/color/-/color-3.0.9.tgz",
+      "integrity": "sha512-dWyK8a3kNii8Yuj1/CQivnVVxsgkV8em+sb0oA29w04t+CFRQywpE2OVV3wZTDzOIVaz3pXx7/X012WoF6d/eQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/numberfield": "^3.11.16",
+        "@react-aria/slider": "^3.7.21",
+        "@react-aria/spinbutton": "^3.6.16",
+        "@react-aria/textfield": "^3.17.5",
+        "@react-aria/utils": "^3.29.1",
+        "@react-aria/visually-hidden": "^3.8.25",
+        "@react-stately/color": "^3.8.6",
+        "@react-stately/form": "^3.1.5",
+        "@react-types/color": "^3.0.6",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/combobox": {
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/combobox/-/combobox-3.12.5.tgz",
+      "integrity": "sha512-mg9RrOTjxQFPy0BQrlqdp5uUC2pLevIqhZit6OfndmOr7khQ32qepDjXoSwYeeSag/jrokc2cGfXfzOwrgAFaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/listbox": "^3.14.6",
+        "@react-aria/live-announcer": "^3.4.3",
+        "@react-aria/menu": "^3.18.5",
+        "@react-aria/overlays": "^3.27.3",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/textfield": "^3.17.5",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/combobox": "^3.10.6",
+        "@react-stately/form": "^3.1.5",
+        "@react-types/button": "^3.12.2",
+        "@react-types/combobox": "^3.13.6",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/datepicker": {
+      "version": "3.14.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/datepicker/-/datepicker-3.14.5.tgz",
+      "integrity": "sha512-TeV/yXEOQ2QOYMxvetWcWUcZN83evmnmG/uSruTdk93e2nZzs227Gg/M95tzgCYRRACCzSzrGujJhNs12Nh7mg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@internationalized/number": "^3.6.3",
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/form": "^3.0.18",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/label": "^3.7.19",
+        "@react-aria/spinbutton": "^3.6.16",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/datepicker": "^3.14.2",
+        "@react-stately/form": "^3.1.5",
+        "@react-types/button": "^3.12.2",
+        "@react-types/calendar": "^3.7.2",
+        "@react-types/datepicker": "^3.12.2",
+        "@react-types/dialog": "^3.5.19",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/dialog": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.5.27.tgz",
+      "integrity": "sha512-Sp8LWQQYNxkLk2+L0bdWmAd9fz1YIrzvxbHXmAn9Tn6+/4SPnQhkOo+qQwtHFbjqe9fyS7cJZxegXd1RegIFew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/overlays": "^3.27.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/dialog": "^3.5.19",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/disclosure": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@react-aria/disclosure/-/disclosure-3.0.6.tgz",
+      "integrity": "sha512-swO7U2G1Qhelj08RUiPQ8OEwDWDGj7DgWBmMyU2HjVEihR9wlvwsJTvzmxNQvJJT0l1bxQ/tM4RWxdUycUYy7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.9",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/disclosure": "^3.0.5",
+        "@react-types/button": "^3.12.2",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/dnd": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/dnd/-/dnd-3.10.1.tgz",
+      "integrity": "sha512-EWiFbRoWs0zBlBbdPvd7gPyA3B8TPUtMfSUnLBCjwc+N0YaUoizZxW2VYgpAkZYAlVrPYV6n2Gs+98PHKZ8rsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/live-announcer": "^3.4.3",
+        "@react-aria/overlays": "^3.27.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/dnd": "^3.6.0",
+        "@react-types/button": "^3.12.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.20.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.20.5.tgz",
+      "integrity": "sha512-JpFtXmWQ0Oca7FcvkqgjSyo6xEP7v3oQOLUId6o0xTvm4AD5W0mU2r3lYrbhsJ+XxdUUX4AVR5473sZZ85kU4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/form": {
+      "version": "3.0.18",
+      "resolved": "https://registry.npmjs.org/@react-aria/form/-/form-3.0.18.tgz",
+      "integrity": "sha512-e4Ktc3NiNwV5dz82zVE7lspYmKwAnGoJfOHgc9MApS7Fy/BEAuVUuLgTjMo1x5me7dY+ADxqrIhbOpifscGGoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/form": "^3.1.5",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/grid": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/grid/-/grid-3.14.2.tgz",
+      "integrity": "sha512-5oS6sLq0DishBvPVsWnxGcUdBRXyFXCj8/n02yJvjbID5Mpjn9JIHUSL4ZCZAO7QGCXpvO3PI40vB2F6QUs2VA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/live-announcer": "^3.4.3",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/grid": "^3.11.3",
+        "@react-stately/selection": "^3.20.3",
+        "@react-types/checkbox": "^3.9.5",
+        "@react-types/grid": "^3.3.3",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/gridlist": {
+      "version": "3.13.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/gridlist/-/gridlist-3.13.2.tgz",
+      "integrity": "sha512-mPGhW2+Jke66LJIPrYoAdL5BBiC8iZ9orjoan7TBTCX9Xk87EK1XLm1cTxAylRqGNjnLzy+vp05Zt2fHY4QduA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/grid": "^3.14.2",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/list": "^3.12.3",
+        "@react-stately/tree": "^3.9.0",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/i18n": {
+      "version": "3.12.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.10.tgz",
+      "integrity": "sha512-1j00soQ2W0nTgzaaIsGFdMF/5aN60AEdCJPhmXGZiuWdWzMxObN9LQ9vdzYPTjTqyqMdSaSp9DZKs5I26Xovpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@internationalized/message": "^3.1.8",
+        "@internationalized/number": "^3.6.3",
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/ssr": "^3.9.9",
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.25.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.25.3.tgz",
+      "integrity": "sha512-J1bhlrNtjPS/fe5uJQ+0c7/jiXniwa4RQlP+Emjfc/iuqpW2RhbF9ou5vROcLzWIyaW8tVMZ468J68rAs/aZ5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.9",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/flags": "^3.1.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/label": {
+      "version": "3.7.19",
+      "resolved": "https://registry.npmjs.org/@react-aria/label/-/label-3.7.19.tgz",
+      "integrity": "sha512-ZJIj/BKf66q52idy24ErzX77vDGuyQn4neWtu51RRSk4npI3pJqEPsdkPCdo2dlBCo/Uc1pfuLGg2hY3N/ni9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/landmark": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@react-aria/landmark/-/landmark-3.0.4.tgz",
+      "integrity": "sha512-1U5ce6cqg1qGbK4M4R6vwrhUrKXuUzReZwHaTrXxEY22IMxKDXIZL8G7pFpcKix2XKqjLZWf+g8ngGuNhtQ2QQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/link": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/link/-/link-3.8.3.tgz",
+      "integrity": "sha512-83gS9Bb+FMa4Tae2VQrOxWixqYhqj4MDt4Bn0i3gzsP/sPWr1bwo5DJmXfw16UAXMaccl1rUKSqqHdigqaealw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/link": "^3.6.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/listbox": {
+      "version": "3.14.6",
+      "resolved": "https://registry.npmjs.org/@react-aria/listbox/-/listbox-3.14.6.tgz",
+      "integrity": "sha512-ZaYpBXiS+nUzxAmeCmXyvDcZECuZi1ZLn5y8uJ4ZFRVqSxqplVHodsQKwKqklmAM3+IVDyQx2WB4/HIKTGg2Bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/label": "^3.7.19",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/list": "^3.12.3",
+        "@react-types/listbox": "^3.7.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/live-announcer": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/live-announcer/-/live-announcer-3.4.3.tgz",
+      "integrity": "sha512-nbBmx30tW53Vlbq3BbMxHGbHa7vGE9ItacI+1XAdH2UZDLtdZA5J6U9YC6lokKQCv+aEVO6Zl9YG4yp57YwnGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-aria/menu": {
+      "version": "3.18.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/menu/-/menu-3.18.5.tgz",
+      "integrity": "sha512-mOQb4PcNvDdFhyqF7nxREwc1YUg+pPTiMNcSHlz/MKFkkUteIQBYfuJJa8i72ooiE55xfYEQhPLjmrLHAOIJ+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/overlays": "^3.27.3",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/menu": "^3.9.5",
+        "@react-stately/selection": "^3.20.3",
+        "@react-stately/tree": "^3.9.0",
+        "@react-types/button": "^3.12.2",
+        "@react-types/menu": "^3.10.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/meter": {
+      "version": "3.4.24",
+      "resolved": "https://registry.npmjs.org/@react-aria/meter/-/meter-3.4.24.tgz",
+      "integrity": "sha512-IYI0Z2pwMvIe8r/3G3PHhM4G/KRiW1ssFCBZdCjBbSpl6/EkmrHiyeaBYG0j8Ux8tmRmXiMVjxLdDlCJQDH7mQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/progress": "^3.4.24",
+        "@react-types/meter": "^3.4.10",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/numberfield": {
+      "version": "3.11.16",
+      "resolved": "https://registry.npmjs.org/@react-aria/numberfield/-/numberfield-3.11.16.tgz",
+      "integrity": "sha512-AGk0BMdHXPP3gSy39UVropyvpNMxAElPGIcicjXXyD/tZdemsgLXUFT2zI4DwE0csFZS8BGgunLWT9VluMF4FQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/spinbutton": "^3.6.16",
+        "@react-aria/textfield": "^3.17.5",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/form": "^3.1.5",
+        "@react-stately/numberfield": "^3.9.13",
+        "@react-types/button": "^3.12.2",
+        "@react-types/numberfield": "^3.8.12",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/overlays": {
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.27.3.tgz",
+      "integrity": "sha512-1hawsRI+QiM0TkPNwApNJ2+N49NQTP+48xq0JG8hdEUPChQLDoJ39cvT1sxdg0mnLDzLaAYkZrgfokq9sX6FLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/ssr": "^3.9.9",
+        "@react-aria/utils": "^3.29.1",
+        "@react-aria/visually-hidden": "^3.8.25",
+        "@react-stately/overlays": "^3.6.17",
+        "@react-types/button": "^3.12.2",
+        "@react-types/overlays": "^3.8.16",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/progress": {
+      "version": "3.4.24",
+      "resolved": "https://registry.npmjs.org/@react-aria/progress/-/progress-3.4.24.tgz",
+      "integrity": "sha512-lpMVrZlSo1Dulo67COCNrcRkJ+lRrC2PI3iRoOIlqw1Ljz4KFoSGyRudg/MLJ/YrQ+6zmNdz5ytdeThrZwHpPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/label": "^3.7.19",
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/progress": "^3.5.13",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/radio": {
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/radio/-/radio-3.11.5.tgz",
+      "integrity": "sha512-6BjpeTupQnxetfvC2bqIxWUt6USMqNZoKOoOO7mUL7ESF6/Gp8ocutvQn0VnTxU+7OhdrZX5AACPg/qIQYumVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/form": "^3.0.18",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/label": "^3.7.19",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/radio": "^3.10.14",
+        "@react-types/radio": "^3.8.10",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/searchfield": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/@react-aria/searchfield/-/searchfield-3.8.6.tgz",
+      "integrity": "sha512-fEhNOtOV5yRZ8hkWmFO5Mh8nq63/ePun2dUMLAiW1sCQXTUpN9Oo+T4vsEUabuZ25mHvqgVoCVhAFdMbvZ+W+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/textfield": "^3.17.5",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/searchfield": "^3.5.13",
+        "@react-types/button": "^3.12.2",
+        "@react-types/searchfield": "^3.6.3",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/select": {
+      "version": "3.15.7",
+      "resolved": "https://registry.npmjs.org/@react-aria/select/-/select-3.15.7.tgz",
+      "integrity": "sha512-b1PpanLblnXgrvIeYPkL9ELdeE3GQXwoRJLNv9DSKSAyBVx+pm6+4BtzngOBdBidRCcOGEBEYxuUW8hMXjFB8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/form": "^3.0.18",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/label": "^3.7.19",
+        "@react-aria/listbox": "^3.14.6",
+        "@react-aria/menu": "^3.18.5",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-aria/visually-hidden": "^3.8.25",
+        "@react-stately/select": "^3.6.14",
+        "@react-types/button": "^3.12.2",
+        "@react-types/select": "^3.9.13",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/selection": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/selection/-/selection-3.24.3.tgz",
+      "integrity": "sha512-QznlHCUcjFgVALUIVBK4SWJd6osaU9lVaZgU4M8uemoIfOHqnBY3zThkQvEhcw/EJ2RpuYYLPOBYZBnk1knD5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/selection": "^3.20.3",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/separator": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/separator/-/separator-3.4.10.tgz",
+      "integrity": "sha512-T9hJpO6lfg6zHRbs5CZD0eZrWIIjN6LY+EC6X5pQJbJeq6HqviVSQx25q98K430S/EGwHRltY5Bwy+XwlMZfdA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/slider": {
+      "version": "3.7.21",
+      "resolved": "https://registry.npmjs.org/@react-aria/slider/-/slider-3.7.21.tgz",
+      "integrity": "sha512-eWu69KnQ7qCmpYBEkgGLjIuKfFqoHu2W6r9d7ys0ZmX81HPj9DhatGpEgHlnjRfCeSl9wL5h2FY9wnIio82cbg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/label": "^3.7.19",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/slider": "^3.6.5",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/slider": "^3.7.12",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/spinbutton": {
+      "version": "3.6.16",
+      "resolved": "https://registry.npmjs.org/@react-aria/spinbutton/-/spinbutton-3.6.16.tgz",
+      "integrity": "sha512-Ko1e9GeQiiEXeR3IyPT8STS1Pw4k/1OBs9LqI3WKlHFwH5M8q3DbbaMOgekD41/CPVBKmCcqFM7K7Wu9kFrT2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/live-announcer": "^3.4.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/button": "^3.12.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.9.tgz",
+      "integrity": "sha512-2P5thfjfPy/np18e5wD4WPt8ydNXhij1jwA8oehxZTFqlgVMGXzcWKxTb4RtJrLFsqPO7RUQTiY8QJk0M4Vy2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/switch": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/switch/-/switch-3.7.5.tgz",
+      "integrity": "sha512-GV9rFYf4wRHAh9tkhptvm3uOflKcQHdgZh+eGpSAHyq2iTq0j2nEhlmtFordpcJgC4XWro7TXLNltfqUqVHtkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/toggle": "^3.11.5",
+        "@react-stately/toggle": "^3.8.5",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/switch": "^3.5.12",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/table": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/table/-/table-3.17.5.tgz",
+      "integrity": "sha512-Q9HDr2EAhoah7HFIT6XxOOOv2fiAs0agwQQd3d1w6jqgyu9m20lM/jxcSwcCFj2O7FPKHfapSAijHDZZoc4Shg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/grid": "^3.14.2",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/live-announcer": "^3.4.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-aria/visually-hidden": "^3.8.25",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/table": "^3.14.3",
+        "@react-types/checkbox": "^3.9.5",
+        "@react-types/grid": "^3.3.3",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/table": "^3.13.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tabs": {
+      "version": "3.10.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/tabs/-/tabs-3.10.5.tgz",
+      "integrity": "sha512-ddmGPikXW+27W2Rx0VuEwwGJVLTo68QkNbSl8R+TEM0EUIAJo3nwHzAlQhuo5Tcb1PdK7biTjO1dyI4pno2/0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/tabs": "^3.8.3",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/tabs": "^3.3.16",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tag": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/tag/-/tag-3.6.2.tgz",
+      "integrity": "sha512-xO33FU0bZSpZ3Bw7bnJz7+Me0daVLJrn5dAllf18Mmf9T2cEr63Gg4AL4nR+rj6NLSq0aH8QyDtRGNqXJjo5SQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/gridlist": "^3.13.2",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/label": "^3.7.19",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/list": "^3.12.3",
+        "@react-types/button": "^3.12.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/textfield": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/textfield/-/textfield-3.17.5.tgz",
+      "integrity": "sha512-HFdvqd3Mdp6WP7uYAWD64gRrL1D4Khi+Fm3dIHBhm1ANV0QjYkphJm4DYNDq/MXCZF46+CZNiOWEbL/aeviykA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/form": "^3.0.18",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/label": "^3.7.19",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/form": "^3.1.5",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/textfield": "^3.12.3",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/toast/-/toast-3.0.5.tgz",
+      "integrity": "sha512-uhwiZqPy6hqucBUL7z6uUZjAJ/ou3bNdTjZlXS+zbcm+T0dsjKDfzNkaebyZY7AX3cYkFCaRjc3N6omXwoAviw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/landmark": "^3.0.4",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/toast": "^3.1.1",
+        "@react-types/button": "^3.12.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toggle": {
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/toggle/-/toggle-3.11.5.tgz",
+      "integrity": "sha512-8+Evk/JVMQ25PNhbnHUvsAK99DAjnCWMdSBNswJ1sWseKCYQzBXsNkkF6Dl/FlSkfDBFAaRHkX9JUz02wehb9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/toggle": "^3.8.5",
+        "@react-types/checkbox": "^3.9.5",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toolbar": {
+      "version": "3.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@react-aria/toolbar/-/toolbar-3.0.0-beta.18.tgz",
+      "integrity": "sha512-P1fXhmTRBK4YvPQDzCY3XoZl+HiBADgvQ89jszxJ2jD4Qzs/E096ttCc+otZnbvRcoU27IxC2vWFInqK/bP31g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tooltip": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/tooltip/-/tooltip-3.8.5.tgz",
+      "integrity": "sha512-spGAuHHNkiqAfyOl4JWzKEK642KC1oQylioYg+LKCq2avUyaDqFlRx2JrC4a6nt3BV6E5/cJUMV9K7gMRApd5Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/tooltip": "^3.5.5",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/tooltip": "^3.4.18",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tree": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/tree/-/tree-3.1.1.tgz",
+      "integrity": "sha512-9LIe9unStA/9HHX6idHdbxMJLjebFP9mngIjoBgbWSNaYx3oH1X3Ei2Q9qHmimebtBagEZgSjxy7M+RcEqFhlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/gridlist": "^3.13.2",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/tree": "^3.9.0",
+        "@react-types/button": "^3.12.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/utils": {
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.29.1.tgz",
+      "integrity": "sha512-yXMFVJ73rbQ/yYE/49n5Uidjw7kh192WNN9PNQGV0Xoc7EJUlSOxqhnpHmYTyO0EotJ8fdM1fMH8durHjUSI8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.9",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/virtualizer": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@react-aria/virtualizer/-/virtualizer-4.1.7.tgz",
+      "integrity": "sha512-mUJAWuLANVd6mXd7SKbGl9+LqrHxgkH/bo9qQTKaRKDWR3PVqU4m/xdY/u2EDGcWPiiTMHLJaPdMQA5OZ8LtMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/virtualizer": "^4.4.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/visually-hidden": {
+      "version": "3.8.25",
+      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.25.tgz",
+      "integrity": "sha512-9tRRFV1YMLuDId9E8PeUf0xy0KmQBoP8y/bm0PKWzXOqLOVmp/+kop9rwsjC7J6ppbBnlak7XCXTc7GoSFOCRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/autocomplete": {
+      "version": "3.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/autocomplete/-/autocomplete-3.0.0-beta.2.tgz",
+      "integrity": "sha512-6I9vFwRmoxnx5MWA5FCflH6PNjY4+bjE7+sUrFHuDf8BhkwGYtQkRGA45P3KR2gK1dECskG1qqw36lqop4zcaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.7",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/calendar": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/calendar/-/calendar-3.8.2.tgz",
+      "integrity": "sha512-IGSbTgCMiGYisQ+CwH31wek10UWvNZ1LVwhr0ZNkhDIRtj+p+FuLNtBnmT1CxTFe2Y4empAxyxNA0QSjQrOtvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/calendar": "^3.7.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/checkbox": {
+      "version": "3.6.15",
+      "resolved": "https://registry.npmjs.org/@react-stately/checkbox/-/checkbox-3.6.15.tgz",
+      "integrity": "sha512-jt3Kzbk6heUMtAlCbUwnrEBknnzFhPBFMEZ00vff7VyhDXup7DJcJRxreloHepARZLIhLhC5QPyO5GS4YOHlvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.1.5",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/checkbox": "^3.9.5",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/collections": {
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.12.5.tgz",
+      "integrity": "sha512-5SIb+6nF9cyu+WXqZ6io56BtdOu8FjSQQaaLCCpfAC6fc6zHRk8by0WreRmvJ5/Kn8oq2FNJtCNRvluM0Z01UA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/color": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/color/-/color-3.8.6.tgz",
+      "integrity": "sha512-KBpnXt31hCgdYq1a7PxUspK990/V5hPO4LqJ1K89p7r2t4OF66IBW5FmOS7KY6p1bGOoZgbk9m5w+yUeQq4wmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/number": "^3.6.3",
+        "@internationalized/string": "^3.2.7",
+        "@react-stately/form": "^3.1.5",
+        "@react-stately/numberfield": "^3.9.13",
+        "@react-stately/slider": "^3.6.5",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/color": "^3.0.6",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/combobox": {
+      "version": "3.10.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/combobox/-/combobox-3.10.6.tgz",
+      "integrity": "sha512-XOfG90MQPfPCNjl2KJOKuFFzx2ULlwnJ/QXl9zCQUtUBOExbFRHldj5E4NPcH14AVeYZX6DBn4GTS9ocOVbE7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/form": "^3.1.5",
+        "@react-stately/list": "^3.12.3",
+        "@react-stately/overlays": "^3.6.17",
+        "@react-stately/select": "^3.6.14",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/combobox": "^3.13.6",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/data": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/data/-/data-3.13.1.tgz",
+      "integrity": "sha512-hKEvHCM/nHM6FFJz3gT6Ms85H+qNhXfHDYP/TU7XiDoeVHzUpj2Yc3xGsIty6/K2k7jrblUj+LuKmdvidd9mug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/datepicker": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/datepicker/-/datepicker-3.14.2.tgz",
+      "integrity": "sha512-KvOUFz/o+hNIb7oCli6nxBdDurbGjRjye6U99GEYAx6timXOjiIJvtKQyqCLRowGYtCS6GH41yM6DhJ2MlMF8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@internationalized/string": "^3.2.7",
+        "@react-stately/form": "^3.1.5",
+        "@react-stately/overlays": "^3.6.17",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/datepicker": "^3.12.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/disclosure": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/disclosure/-/disclosure-3.0.5.tgz",
+      "integrity": "sha512-Rh+y+XAUNwyFvvzBS/MtFvdWHC38mXI99S6mdNe3e5Og8IZxLBDtvwBCzrT30YzYqN40yd3alm9xLzpYXsvYYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/dnd": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/dnd/-/dnd-3.6.0.tgz",
+      "integrity": "sha512-H0zWOjjoocM+8r5rJ2x0B66NXZd2+7lF1zhomoMoR5+57DA5hWZTY0tht21DKjNoFk4f96Ythh0jRLziQbSkBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/selection": "^3.20.3",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/flags": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
+      "integrity": "sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-stately/form": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/form/-/form-3.1.5.tgz",
+      "integrity": "sha512-wOs0SVXFgNr1aIdywiNH1MhxrFlN5YxBr1k9y3Z7lX+pc/MGRJFTgfDDw5JDxvwLH9joJ9ciniCdWep9L/TqcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/grid": {
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/grid/-/grid-3.11.3.tgz",
+      "integrity": "sha512-/YurYfPARtgsgS5f8rklB7ZQu6MWLdpfTHuwOELEUZ4L52S2gGA5VfLxDnAsHHnu5XHFI3ScuYLAvjWN0rgs/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/selection": "^3.20.3",
+        "@react-types/grid": "^3.3.3",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/layout": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/layout/-/layout-4.3.1.tgz",
+      "integrity": "sha512-W2aa60I3qCI24HzZaFsS/eV1aCL0YI3IOlYm9PgsbELP82y3n7YRnwVreUv30KVdpn0VviLZn2xdWSeZlyqi9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/table": "^3.14.3",
+        "@react-stately/virtualizer": "^4.4.1",
+        "@react-types/grid": "^3.3.3",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/table": "^3.13.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/list": {
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/list/-/list-3.12.3.tgz",
+      "integrity": "sha512-RiqYyxPYAF3YRBEin8/WHC8/hvpZ/fG1Tx3h1W4aXU5zTIBuy0DrjRKePwP90oCiDpztgRXePLlzhgWeKvJEow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/selection": "^3.20.3",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/menu": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/menu/-/menu-3.9.5.tgz",
+      "integrity": "sha512-Y+PqHBaQToo6ooCB4i4RoNfRiHbd4iozmLWePBrF4d/zBzJ9p+/5O6XIWFxLw4O128Tg3tSMGuwrxfecPDYHzA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/overlays": "^3.6.17",
+        "@react-types/menu": "^3.10.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/numberfield": {
+      "version": "3.9.13",
+      "resolved": "https://registry.npmjs.org/@react-stately/numberfield/-/numberfield-3.9.13.tgz",
+      "integrity": "sha512-FWbbL4E3+5uctPGVtDwHzeNXgyFw0D3glOJhgW1QHPn3qIswusn0z/NjFSuCVOSpri8BZYIrTPUQHpRJPnjgRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/number": "^3.6.3",
+        "@react-stately/form": "^3.1.5",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/numberfield": "^3.8.12",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/overlays": {
+      "version": "3.6.17",
+      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.17.tgz",
+      "integrity": "sha512-bkGYU4NPC/LgX9OGHLG8hpf9QDoazlb6fKfD+b5o7GtOdctBqCR287T/IBOQyvHqpySqrQ8XlyaGxJPGIcCiZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/overlays": "^3.8.16",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/radio": {
+      "version": "3.10.14",
+      "resolved": "https://registry.npmjs.org/@react-stately/radio/-/radio-3.10.14.tgz",
+      "integrity": "sha512-Y7xizUWJ0YJ8pEtqMeKOibX21B5dk56fHgMHXYLeUEm43y5muWQft2YvP0/n4mlkP2Isbk96kPbv7/ez3Gi+lA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.1.5",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/radio": "^3.8.10",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/searchfield": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@react-stately/searchfield/-/searchfield-3.5.13.tgz",
+      "integrity": "sha512-JNvsnvK6A1057hQREHabRYAAtwj2vl20oqGBvl1IleKlFe3KInV9WBY5l6zR3RXrnCPHVvJuzGe2R7+g142Mnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/searchfield": "^3.6.3",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/select": {
+      "version": "3.6.14",
+      "resolved": "https://registry.npmjs.org/@react-stately/select/-/select-3.6.14.tgz",
+      "integrity": "sha512-HvbL9iMGwbev0FR6PzivhjKEcXADgcJC/IzUkLqPfg4KKMuYhM/XvbJjWXn/QpD3/XT+A5+r5ExUHu7wiDP93w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.1.5",
+        "@react-stately/list": "^3.12.3",
+        "@react-stately/overlays": "^3.6.17",
+        "@react-types/select": "^3.9.13",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/selection": {
+      "version": "3.20.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/selection/-/selection-3.20.3.tgz",
+      "integrity": "sha512-TLyjodgFHn5fynQnRmZ5YX1HRY0KC7XBW0Nf2+q9mWk4gUxYm7RVXyYZvMIG1iKqinPYtySPRHdNzyXq9P9sxQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/slider": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/slider/-/slider-3.6.5.tgz",
+      "integrity": "sha512-XnHSHbXeHiE5J7nsXQvlXaKaNn1Z4jO1aQyiZsolK1NXW6VMKVeAgZUBG45k7xQW06aRbjREMmiIz02mW8fajQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/slider": "^3.7.12",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/table": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/table/-/table-3.14.3.tgz",
+      "integrity": "sha512-PwE5pCplLSDckvgmNLVaHyQyX04A62kxdouFh1dVHeGEPfOYsO9WhvyisLxbH7X8Dbveheq/tSTelYDi6LXEJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/grid": "^3.11.3",
+        "@react-stately/selection": "^3.20.3",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/grid": "^3.3.3",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/table": "^3.13.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tabs": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/tabs/-/tabs-3.8.3.tgz",
+      "integrity": "sha512-FujQCHppXyeHs2v5FESekxodsBJ5T0k1f7sm0ViNYqgrnE5XwqX8Y4/tdr0fqGF6S+BBllH+Q9yKWipDc6OM8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/list": "^3.12.3",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/tabs": "^3.3.16",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/toast": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/toast/-/toast-3.1.1.tgz",
+      "integrity": "sha512-W4a6xcsFt/E+aHmR2eZK+/p7Y5rdyXSCQ5gKSnbck+S3lijEWAyV45Mv8v95CQqu0bQijj6sy2Js1szq10HVwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/toggle": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.8.5.tgz",
+      "integrity": "sha512-BSvuTDVFzIKxpNg9Slf+RdGpva7kBO8xYaec2TW9m6Ag9AOmiDwUzzDAO0DRsc7ArSaLLFaQ/pdmmT6TxAUQIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/checkbox": "^3.9.5",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tooltip": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/tooltip/-/tooltip-3.5.5.tgz",
+      "integrity": "sha512-/zbl7YxneGDGGzdMPSEYUKsnVRGgvsr80ZjQYBHL82N4tzvtkRwmzvzN9ipAtza+0jmeftt3N+YSyxvizVbeKA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/overlays": "^3.6.17",
+        "@react-types/tooltip": "^3.4.18",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tree": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/tree/-/tree-3.9.0.tgz",
+      "integrity": "sha512-VpWAh36tbMHJ1CtglPQ81KPdpCfqFz9yAC6nQuL1x6Tmbs9vNEKloGILMI9/4qLzC+3nhCVJj6hN+xqS5/cMTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/selection": "^3.20.3",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/utils": {
+      "version": "3.10.7",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.7.tgz",
+      "integrity": "sha512-cWvjGAocvy4abO9zbr6PW6taHgF24Mwy/LbQ4TC4Aq3tKdKDntxyD+sh7AkSRfJRT2ccMVaHVv2+FfHThd3PKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/virtualizer": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/virtualizer/-/virtualizer-4.4.1.tgz",
+      "integrity": "sha512-ZjhsmsNqKY4HrTuT9ySh8lNmYHGgFX24CVVQ3hMr8dTzO9DRR89BMrmenoVtMj7NkonWF8lUFyYlVlsijs2p4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/autocomplete": {
+      "version": "3.0.0-alpha.32",
+      "resolved": "https://registry.npmjs.org/@react-types/autocomplete/-/autocomplete-3.0.0-alpha.32.tgz",
+      "integrity": "sha512-eRi5n+QMMI3IUMX8z2+dnbQXaTgEgsmp2Qg1a/6HobJzq3IviIjkrG1B4jwp+kZHca7OuVa2ouiWvBu9sW9o4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/combobox": "^3.13.6",
+        "@react-types/searchfield": "^3.6.3",
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/breadcrumbs": {
+      "version": "3.7.14",
+      "resolved": "https://registry.npmjs.org/@react-types/breadcrumbs/-/breadcrumbs-3.7.14.tgz",
+      "integrity": "sha512-SbLjrKKupzCLbqHZIQYtQvtsXN53NPxOYyug6QfC4d7DcW1Q9wJ546fxb10Y83ftAJMMUHTatI6SenJVoqyUdA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/link": "^3.6.2",
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/button": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.12.2.tgz",
+      "integrity": "sha512-QLoSCX8E7NFIdkVMa65TPieve0rKeltfcIxiMtrphjfNn+83L0IHMcbhjf4r4W19c/zqGbw3E53Hx8mNukoTUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/calendar": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@react-types/calendar/-/calendar-3.7.2.tgz",
+      "integrity": "sha512-Bp6fZo52fZdUjYbtJXcaLQ0jWEOeSoyZVwNyN5G6BmPyLP5nHxMPF+R1MPFR0fdpSI4/Sk78gWzoTuU5eOVQLw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/checkbox": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.9.5.tgz",
+      "integrity": "sha512-9y8zeGWT2xZ38/YC/rNd05pPV8W8vmqFygCpZFaa6dJeOsMgPU+rq+Ifh1G+34D/qGoZXQBzeCSCAKSNPaL7uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/color": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@react-types/color/-/color-3.0.6.tgz",
+      "integrity": "sha512-ZbbgzAWK56RMMZzRGhTAB9Fz9PGnj6ctc6VMqOyumCOF9NKkYgI0E2ssTY/iOXBazZvhhhGahbGl+kjmgWvS6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0",
+        "@react-types/slider": "^3.7.12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/combobox": {
+      "version": "3.13.6",
+      "resolved": "https://registry.npmjs.org/@react-types/combobox/-/combobox-3.13.6.tgz",
+      "integrity": "sha512-BOvlyoVtmQJLYtNt4w6RvRORqK4eawW48CcQIR93BU5YFcAGhpcvpjhTZXknSXumabpo1/XQKX4NOuXpfUZrAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/datepicker": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@react-types/datepicker/-/datepicker-3.12.2.tgz",
+      "integrity": "sha512-w3JIXZLLZ15zjrAjlnflmCXkNDmIelcaChhmslTVWCf0lUpgu1cUC4WAaS71rOgU03SCcrtQ0K9TsYfhnhhL7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@react-types/calendar": "^3.7.2",
+        "@react-types/overlays": "^3.8.16",
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/dialog": {
+      "version": "3.5.19",
+      "resolved": "https://registry.npmjs.org/@react-types/dialog/-/dialog-3.5.19.tgz",
+      "integrity": "sha512-+FIyFnoKIGNL20zG8Sye7rrRxmt5HoeaCaHhDCTtNtv8CZEhm3Z+kNd4gylgWAxZRhDtBRWko+ADqfN5gQrgKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.8.16",
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/form": {
+      "version": "3.7.13",
+      "resolved": "https://registry.npmjs.org/@react-types/form/-/form-3.7.13.tgz",
+      "integrity": "sha512-Ryw9QDLpHi0xsNe+eucgpADeaRSmsd7+SBsL15soEXJ50K/EoPtQOkm6fE4lhfqAX8or12UF9FBcBLULmfCVNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/grid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@react-types/grid/-/grid-3.3.3.tgz",
+      "integrity": "sha512-VZAKO3XISc/3+a+DZ+hUx2NB/buOe2Ui2nISutv25foeXX4+YpWj5lXS74lJUCuVsSz6D6yoWvEajeUCYrNOxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/link": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@react-types/link/-/link-3.6.2.tgz",
+      "integrity": "sha512-CtCexoupcaFHJdVPRUpJ83uxK1U0bd9x9DhwRFMqqfPHufICkQkETIw2KIeZXRvMUMi2CSG/81XXy6K0K1MtNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/listbox": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@react-types/listbox/-/listbox-3.7.1.tgz",
+      "integrity": "sha512-WiCihJJpVWVEUxxZjhTbnG3Zq3q38XylKnvNelkVHbF+Y3+SXWN0Yyhk43J642G/d87lw1t60Tor0k96eaz4vw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/menu": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@react-types/menu/-/menu-3.10.2.tgz",
+      "integrity": "sha512-TVQFGttaNCcIvy1MKavb9ZihJmng46uUtVF9oTG/VI/C4YEdzekteI6iSsXbjv5ZAvOKQR+S25IWCbK2W0YCjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.8.16",
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/meter": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@react-types/meter/-/meter-3.4.10.tgz",
+      "integrity": "sha512-soimx+MAngG5MjQplJNB9erPh+P3Er764PqGA75L6FFmf2KhgzMniSVAqyVOpZu7G3qK4O+ihMAYXf6pQMBkSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/progress": "^3.5.13"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/numberfield": {
+      "version": "3.8.12",
+      "resolved": "https://registry.npmjs.org/@react-types/numberfield/-/numberfield-3.8.12.tgz",
+      "integrity": "sha512-cI0Grj+iW5840gV80t7aXt7FZPbxMZufjuAop5taHe6RlHuLuODfz5n3kyu/NPHabruF26mVEu0BfIrwZyy+VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/overlays": {
+      "version": "3.8.16",
+      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.16.tgz",
+      "integrity": "sha512-Aj9jIFwALk9LiOV/s3rVie+vr5qWfaJp/6aGOuc2StSNDTHvj1urSAr3T0bT8wDlkrqnlS4JjEGE40ypfOkbAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/progress": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@react-types/progress/-/progress-3.5.13.tgz",
+      "integrity": "sha512-+4v++AP2xxYxjrTkIXlWWGUhPPIEBzyg76EW0SHKnD4pXxKigcIXEzRbxy62SMidTVdi7jh3tuicIP8OQxJ4cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/radio": {
+      "version": "3.8.10",
+      "resolved": "https://registry.npmjs.org/@react-types/radio/-/radio-3.8.10.tgz",
+      "integrity": "sha512-hLOu2CXxzxQqkEkXSM71jEJMnU5HvSzwQ+DbJISDjgfgAKvZZHMQX94Fht2Vj+402OdI77esl3pJ1tlSLyV5VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/searchfield": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@react-types/searchfield/-/searchfield-3.6.3.tgz",
+      "integrity": "sha512-Uua7TYKR1QcJE2F4SAewxuxt8k8gd52zul2q5oMe5azsm2uoAtV/qpNHc7dfPAR97UgbrE/aNMlX57PEubiuLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0",
+        "@react-types/textfield": "^3.12.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/select": {
+      "version": "3.9.13",
+      "resolved": "https://registry.npmjs.org/@react-types/select/-/select-3.9.13.tgz",
+      "integrity": "sha512-R7zwck353RV60gZimZ8pDKaj50aEtGzU8gk0jC3aBkfzSUKFJ6jq1DJdqyVQSwXdmPDd9iuketeIUIpEO2teoA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.30.0.tgz",
+      "integrity": "sha512-COIazDAx1ncDg046cTJ8SFYsX8aS3lB/08LDnbkH/SkdYrFPWDlXMrO/sUam8j1WWM+PJ+4d1mj7tODIKNiFog==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/slider": {
+      "version": "3.7.12",
+      "resolved": "https://registry.npmjs.org/@react-types/slider/-/slider-3.7.12.tgz",
+      "integrity": "sha512-kOQLrENLpQzmu6TfavdW1yfEc8VPitT4ZNMKOK0h7x3LskEWjptxcZ4IBowEpqHwk0eMbI9lRE/3tsShGUoLwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/switch": {
+      "version": "3.5.12",
+      "resolved": "https://registry.npmjs.org/@react-types/switch/-/switch-3.5.12.tgz",
+      "integrity": "sha512-6Zz7i+L9k8zw2c3nO8XErxuIy7JVDptz1NTZMiUeyDtLmQnvEKnKPKNjo2j+C/OngtJqAPowC3xRvMXbSAcYqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/table": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@react-types/table/-/table-3.13.1.tgz",
+      "integrity": "sha512-fLPRXrZoplAGMjqxHVLMt7lB0qsiu1WHZmhKtroCEhTYwnLQKL84XFH4GV1sQgQ1GIShl3BUqWzrawU5tEaQkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/grid": "^3.3.3",
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/tabs": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/@react-types/tabs/-/tabs-3.3.16.tgz",
+      "integrity": "sha512-z6AWq243EahGuT4PhIpJXZbFez6XhFWb4KwhSB2CqzHkG5bJJSgKYzIcNuBCLDxO7Qg25I+VpFJxGj+aqKFbzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/textfield": {
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/@react-types/textfield/-/textfield-3.12.3.tgz",
+      "integrity": "sha512-72tt2GJSyVFPPqZLrlfWqVn5KRnWzXsXCZ3IDawcGunl4pu+2E24jd0CWN9kOi0ETO65flj2sljeytxKytXnlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/tooltip": {
+      "version": "3.4.18",
+      "resolved": "https://registry.npmjs.org/@react-types/tooltip/-/tooltip-3.4.18.tgz",
+      "integrity": "sha512-/eG8hiW0D4vaCqGDa4ttb+Jnbiz6nUr5+f+LRgz3AnIkdjS9eOhpn6vXMX4hkNgcN5FGfA4Uu1C1QdM6W97Kfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.8.16",
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.34.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.1.tgz",
@@ -7069,6 +8954,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@tanstack/eslint-plugin-query": {
@@ -8570,6 +10464,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -8910,6 +10810,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.1.0",
@@ -10142,6 +12048,18 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
       "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
       "license": "MIT"
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.16",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
+      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.2",
+        "tslib": "^2.8.0"
+      }
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -12654,6 +14572,100 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-aria": {
+      "version": "3.41.1",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.41.1.tgz",
+      "integrity": "sha512-5mujwnW6/NHvONDecb7DiWkzI27dzBO1auKt4KkgNuW+Awud1LCaK/NOlHp4xZl3fSfh1ROpdAKERHCh7nvAAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/breadcrumbs": "^3.5.26",
+        "@react-aria/button": "^3.13.3",
+        "@react-aria/calendar": "^3.8.3",
+        "@react-aria/checkbox": "^3.15.7",
+        "@react-aria/color": "^3.0.9",
+        "@react-aria/combobox": "^3.12.5",
+        "@react-aria/datepicker": "^3.14.5",
+        "@react-aria/dialog": "^3.5.27",
+        "@react-aria/disclosure": "^3.0.6",
+        "@react-aria/dnd": "^3.10.1",
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/gridlist": "^3.13.2",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/label": "^3.7.19",
+        "@react-aria/landmark": "^3.0.4",
+        "@react-aria/link": "^3.8.3",
+        "@react-aria/listbox": "^3.14.6",
+        "@react-aria/menu": "^3.18.5",
+        "@react-aria/meter": "^3.4.24",
+        "@react-aria/numberfield": "^3.11.16",
+        "@react-aria/overlays": "^3.27.3",
+        "@react-aria/progress": "^3.4.24",
+        "@react-aria/radio": "^3.11.5",
+        "@react-aria/searchfield": "^3.8.6",
+        "@react-aria/select": "^3.15.7",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/separator": "^3.4.10",
+        "@react-aria/slider": "^3.7.21",
+        "@react-aria/ssr": "^3.9.9",
+        "@react-aria/switch": "^3.7.5",
+        "@react-aria/table": "^3.17.5",
+        "@react-aria/tabs": "^3.10.5",
+        "@react-aria/tag": "^3.6.2",
+        "@react-aria/textfield": "^3.17.5",
+        "@react-aria/toast": "^3.0.5",
+        "@react-aria/tooltip": "^3.8.5",
+        "@react-aria/tree": "^3.1.1",
+        "@react-aria/utils": "^3.29.1",
+        "@react-aria/visually-hidden": "^3.8.25",
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-aria-components": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/react-aria-components/-/react-aria-components-1.10.1.tgz",
+      "integrity": "sha512-Mllbk2pQax2EwlOJsXG4oTp6P7P33m82/47M9Os+zaGhSCqo2EilFvThxCFxhLa7ncjLV0ka6wFIYLmZiOcWxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/autocomplete": "3.0.0-beta.5",
+        "@react-aria/collections": "3.0.0-rc.3",
+        "@react-aria/dnd": "^3.10.1",
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/live-announcer": "^3.4.3",
+        "@react-aria/overlays": "^3.27.3",
+        "@react-aria/ssr": "^3.9.9",
+        "@react-aria/toolbar": "3.0.0-beta.18",
+        "@react-aria/utils": "^3.29.1",
+        "@react-aria/virtualizer": "^4.1.7",
+        "@react-stately/autocomplete": "3.0.0-beta.2",
+        "@react-stately/layout": "^4.3.1",
+        "@react-stately/selection": "^3.20.3",
+        "@react-stately/table": "^3.14.3",
+        "@react-stately/utils": "^3.10.7",
+        "@react-stately/virtualizer": "^4.4.1",
+        "@react-types/form": "^3.7.13",
+        "@react-types/grid": "^3.3.3",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/table": "^3.13.1",
+        "@swc/helpers": "^0.5.0",
+        "client-only": "^0.0.1",
+        "react-aria": "^3.41.1",
+        "react-stately": "^3.39.0",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
@@ -12716,6 +14728,43 @@
       "peerDependencies": {
         "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
         "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/react-stately": {
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.39.0.tgz",
+      "integrity": "sha512-/8JC3Tmj7G8fHn47F88c6t5kFNhQAufwqjEKxYeNi7TPz9UL+35BeoH1poMmDHJsPz8qM/z4sWMzaW5AwYK8lQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/calendar": "^3.8.2",
+        "@react-stately/checkbox": "^3.6.15",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/color": "^3.8.6",
+        "@react-stately/combobox": "^3.10.6",
+        "@react-stately/data": "^3.13.1",
+        "@react-stately/datepicker": "^3.14.2",
+        "@react-stately/disclosure": "^3.0.5",
+        "@react-stately/dnd": "^3.6.0",
+        "@react-stately/form": "^3.1.5",
+        "@react-stately/list": "^3.12.3",
+        "@react-stately/menu": "^3.9.5",
+        "@react-stately/numberfield": "^3.9.13",
+        "@react-stately/overlays": "^3.6.17",
+        "@react-stately/radio": "^3.10.14",
+        "@react-stately/searchfield": "^3.5.13",
+        "@react-stately/select": "^3.6.14",
+        "@react-stately/selection": "^3.20.3",
+        "@react-stately/slider": "^3.6.5",
+        "@react-stately/table": "^3.14.3",
+        "@react-stately/tabs": "^3.8.3",
+        "@react-stately/toast": "^3.1.1",
+        "@react-stately/toggle": "^3.8.5",
+        "@react-stately/tooltip": "^3.5.5",
+        "@react-stately/tree": "^3.9.0",
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/react-transition-group": {
@@ -13658,6 +15707,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.19.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "js-yaml": "^4.1.0",
     "rdf-data-factory": "^2.0.2",
     "react": "19.0.0",
+    "react-aria-components": "^1.10.1",
     "react-dom": "19.0.0",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^2.1.7",

--- a/src/data/examples.ts
+++ b/src/data/examples.ts
@@ -45,18 +45,20 @@ const examplesFrontmatterSchema = v.object({
   tags: v.array(v.string()),
 });
 
-type ExampleNode =
+export type ExampleNode = {
+  title: string;
+  sha: string;
+} & (
   | {
       type: "example";
-      title: string;
       sources: string[];
       query: string;
     }
   | {
       type: "folder";
-      title: string;
       children: ExampleNode[];
-    };
+    }
+);
 
 export async function fetchExamples(): Promise<ExampleNode[]> {
   const fileTree = await getFilesFromGithub(
@@ -83,6 +85,7 @@ export async function fetchExamples(): Promise<ExampleNode[]> {
         return {
           type: "example",
           title: summary,
+          sha: fileNode.sha,
           sources: tags,
           query: sparql,
         };
@@ -90,6 +93,7 @@ export async function fetchExamples(): Promise<ExampleNode[]> {
         return {
           type: "folder",
           title: fileNode.name,
+          sha: fileNode.sha,
           children: traverse(fileNode.children),
         };
       }

--- a/src/data/examples.ts
+++ b/src/data/examples.ts
@@ -32,7 +32,8 @@ function extractSparqlFrontMatter(sparql: string, removeFrontmatter = true): {
           .split("\n")
           .slice(splitLineNumber + 1, -1)
           .join("\n")
-      : sparql,
+          .trim()
+      : sparql.trim(),
   }
 }
 

--- a/src/data/github-utils.ts
+++ b/src/data/github-utils.ts
@@ -35,6 +35,9 @@ export const getFilesFromGithubFlattened = async (path: string, maxDepth = 2): P
       method: "get",
       headers: {
         Accept: "application/vnd.github+json",
+        ...(import.meta.env.VITE_GH_TOKEN && ({
+          Authorization: `Bearer ${import.meta.env.VITE_GH_TOKEN}`,
+        }))
       },
     });
     if (!res.ok) throw new Error("Error fetching from Github API: " + res.statusText);

--- a/src/data/github-utils.ts
+++ b/src/data/github-utils.ts
@@ -1,72 +1,114 @@
-import * as v from 'valibot';
+import * as v from "valibot";
 
-const githubDirectorySchema = v.array(v.looseObject({
-  download_url: v.nullable(v.string()),
-  type: v.union([v.literal("file"), v.literal("dir")]),
-  _links: v.looseObject({
-    self: v.pipe(v.string(), v.url()),
-  }),
-}));
+const githubDirectorySchema = v.array(
+  v.looseObject({
+    name: v.string(),
+    download_url: v.nullable(v.string()),
+    type: v.union([v.literal("file"), v.literal("dir")]),
+    _links: v.looseObject({
+      self: v.pipe(v.string(), v.url()),
+    }),
+  })
+);
+
+export type FileNode =
+  | {
+      type: "dir";
+      name: string;
+      children: FileNode[];
+    }
+  | {
+      type: "file";
+      contents: string;
+    };
 
 /**
- * Gets the files from a public Github directory and flattens the results into
- * a string array.
+ * Gets a tree of files from a public Github directory.
  * @param directory the directory in Github. This directory needs to be public.
  * Formatted like this: `{owner}/{repo}/{path_to_directory}
  * @param maxDepth the depth of the subdirectory tree to search. 1 means only files
  * in the top level directory will included in the output.
- * @returns a list of files in the directory, including nested folders up to the
- * specified depth, flattened
- * @warn this function can cause request waterfalls that take a long time, 
+ * @returns a tree of files in the directory, including nested folders up to the
+ * specified depth
+ * @warn this function can cause request waterfalls that take a long time,
  * especially with a large `maxDepth` or on a directory with many files.
  * @link https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content
  */
-export const getFilesFromGithubFlattened = async (path: string, maxDepth = 2): Promise<string[]> => {
+export const getFilesFromGithub = async (
+  path: string,
+  maxDepth = 2
+): Promise<FileNode[]> => {
   const apiBase = `https://api.github.com/repos/${import.meta.env.VITE_GH_REPO}/contents`;
 
-  const traverse = async (url: string, depth = 0): Promise<string[]> => {
-    const output: string[] = [];
-  
+  const traverse = async (url: string, depth = 0): Promise<FileNode[]> => {
+    const output: FileNode[] = [];
+
     if (depth >= maxDepth) {
       return output;
     }
-  
+
     const res = await fetch(url, {
       method: "get",
       headers: {
         Accept: "application/vnd.github+json",
-        ...(import.meta.env.VITE_GH_TOKEN && ({
+        ...(import.meta.env.VITE_GH_TOKEN && {
           Authorization: `Bearer ${import.meta.env.VITE_GH_TOKEN}`,
-        }))
+        }),
       },
     });
-    if (!res.ok) throw new Error("Error fetching from Github API: " + res.statusText);
-    const validatorResult = v.safeParse(githubDirectorySchema, await res.json());
+    if (!res.ok)
+      throw new Error("Error fetching from Github API: " + res.statusText);
+    const validatorResult = v.safeParse(
+      githubDirectorySchema,
+      await res.json()
+    );
     if (!validatorResult.success) {
-      throw new Error("Error validating Github API response: \n" + validatorResult.issues);
+      throw new Error(
+        "Error validating Github API response: \n" + validatorResult.issues
+      );
     }
     const data = validatorResult.output;
-  
-    const fileQueries = data
+
+    const fileQueries: Promise<string>[] = data
       .map(({ download_url }) => download_url)
-      .filter(url => url !== null)
-      .map(url => fetch(url).then(res => {
-        if (!res.ok) throw new Error("Error fetching from Github API: " + res.statusText);
-        return res.text();
-      }));
-  
-    const nestedFiles = await Promise.all(
-      data
-        .filter((entry) => entry.type === "dir")
-        .map((dir) => traverse(dir._links.self, depth + 1))
+      .filter((url) => url !== null)
+      .map((url) =>
+        fetch(url).then((res) => {
+          if (!res.ok)
+            throw new Error(
+              "Error fetching from Github API: " + res.statusText
+            );
+          return res.text();
+        })
+      );
+
+    const directories: FileNode[] = (
+      await Promise.all(
+        data
+          .filter((entry) => entry.type === "dir")
+          .map((dir) =>
+            traverse(dir._links.self, depth + 1).then((children) => ({
+              parentName: dir.name,
+              children,
+            }))
+          )
+      )
+    ).map(({ parentName, children }) => ({
+      type: "dir" as const,
+      name: parentName,
+      children,
+    }));
+
+    const files: FileNode[] = (await Promise.all(fileQueries)).map(
+      (contents) => ({
+        type: "file" as const,
+        contents,
+      })
     );
-    nestedFiles.forEach(files => output.push(...files));
-  
-    const files = await Promise.all(fileQueries);
-    output.push(...files);
-  
+
+    output.push(...directories, ...files);
     return output;
   };
 
   return traverse(apiBase + path);
-}
+};

--- a/src/ui/ExampleTree.tsx
+++ b/src/ui/ExampleTree.tsx
@@ -1,0 +1,103 @@
+import { Folder, FolderOpen } from "@mui/icons-material";
+import type { ExampleNode } from "../data/examples";
+import {
+  Collection,
+  Tree,
+  TreeItem,
+  TreeItemContent,
+} from "react-aria-components";
+import { styled } from "@mui/joy";
+import { Link } from "@tanstack/react-router";
+
+export function ExampleTree({ rootNodes }: { rootNodes: ExampleNode[] }) {
+  return (
+    <StyledTree items={rootNodes}>
+      {/* @ts-ignore the styled component causes the renderItem function to throw a type warning */}
+      {function renderItem(item: ExampleNode) {
+        return (
+          <TreeItem textValue={item.title} id={item.sha}>
+            <TreeItemContent>
+              {({ isExpanded }) =>
+                item.type === "folder" ? (
+                  <FolderItem item={item} isExpanded={isExpanded} />
+                ) : (
+                  <ExampleItem item={item} />
+                )
+              }
+            </TreeItemContent>
+            {item.type === "folder" && item.children.length > 0 && (
+              <Collection items={item.children}>{renderItem}</Collection>
+            )}
+          </TreeItem>
+        );
+      }}
+    </StyledTree>
+  );
+}
+
+interface FolderItemProps {
+  item: Extract<ExampleNode, { type: "folder" }>;
+  isExpanded: boolean;
+}
+const FolderItem = ({ item, isExpanded }: FolderItemProps) => (
+  <FolderItemWrapper>
+    {item.type === "folder" &&
+      (isExpanded ? (
+        <FolderOpen htmlColor="var(--p-slate-400)" />
+      ) : (
+        <Folder htmlColor="var(--p-slate-400)" />
+      ))}
+    {item.title}
+  </FolderItemWrapper>
+);
+
+interface ExampleItemProps {
+  item: Extract<ExampleNode, { type: "example" }>;
+}
+const ExampleItem = ({ item }: ExampleItemProps) => (
+  <Link to={"/"} search={{ query: item.query, sources: item.sources }}>
+    {item.title}
+    {item.sources.map((s) => (
+      <Chip key={s}>{s}</Chip>
+    ))}
+  </Link>
+);
+
+const StyledTree = styled(Tree)`
+  display: flex;
+  flex-direction: column;
+
+  & > div:not(:last-of-type) {
+    padding-bottom: 0.25rem;
+    margin-bottom: 0.25rem;
+    border-bottom: 1px dotted var(--p-slate-300);
+  }
+
+  & .react-aria-TreeItem {
+    --gap: 4px;
+    --icon-size: 24px; // this should match the folder icon size
+    margin-left: calc(
+      (var(--tree-item-level) - 1) * (var(--icon-size) + var(--gap))
+    );
+  }
+`;
+
+const FolderItemWrapper = styled("div")`
+  cursor: pointer;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--gap);
+`;
+
+const Chip = styled("span")`
+  font-size: 0.7rem;
+  font-weight: 500;
+  padding: 2px 4px;
+  background-color: var(--p-slate-200);
+  border-radius: 6px;
+  transform: translateY(-1.5px);
+  margin-left: 1ch;
+  color: var(--p-slate-700);
+  display: inline-block; // removes underline
+`;

--- a/src/ui/Panels/Examples.tsx
+++ b/src/ui/Panels/Examples.tsx
@@ -12,10 +12,10 @@ export function Examples() {
   } = useQuery({
     queryKey: ["examples"],
     queryFn: fetchExamples,
-    staleTime: 24 * 60 * 60 * 1000,
-    refetchOnMount: false,
+    staleTime: 0,
+    refetchOnMount: true,
   })
-  
+
   return (
     <Wrapper>
       {
@@ -31,7 +31,7 @@ export function Examples() {
             </p>
             <hr />
             <QueriesWrapper>
-              {examples.map((example) => (
+              {/* {examples.map((example) => (
                 <div key={example.title}>
                   <Link
                     to={"/"}
@@ -43,7 +43,7 @@ export function Examples() {
                     ))}
                   </Link>
                 </div>
-              ))}
+              ))} */}
             </QueriesWrapper>
           </>
         )

--- a/src/ui/Panels/Examples.tsx
+++ b/src/ui/Panels/Examples.tsx
@@ -1,7 +1,7 @@
 import { styled } from "@mui/joy";
 import { useQuery } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
 import { fetchExamples } from "../../data/examples";
+import { ExampleTree } from "../ExampleTree";
 
 export function Examples() {
   const {
@@ -14,40 +14,24 @@ export function Examples() {
     queryFn: fetchExamples,
     staleTime: 0,
     refetchOnMount: true,
-  })
+  });
 
   return (
     <Wrapper>
-      {
-        isLoading || !examples ? (
-          <div>Loading...</div>
-        ) : isError ? (
-          <div>{error.message}</div>
-        ) : (
-          <>
-            <p>
-              Select a example query below to load it into the <mark>query</mark>{" "}
-              panel. Then press the "Run Query" button to execute the query.
-            </p>
-            <hr />
-            <QueriesWrapper>
-              {/* {examples.map((example) => (
-                <div key={example.title}>
-                  <Link
-                    to={"/"}
-                    search={{ query: example.query, sources: example.sources }}
-                  >
-                    {example.title}
-                    {example.sources.map((s) => (
-                      <Chip key={s}>{s}</Chip>
-                    ))}
-                  </Link>
-                </div>
-              ))} */}
-            </QueriesWrapper>
-          </>
-        )
-      }
+      {isLoading || !examples ? (
+        <div>Loading...</div>
+      ) : isError ? (
+        <div>{error.message}</div>
+      ) : (
+        <>
+          <p>
+            Select a example query below to load it into the <mark>query</mark>{" "}
+            panel. Then press the "Run Query" button to execute the query.
+          </p>
+          <hr />
+          <ExampleTree rootNodes={examples} />
+        </>
+      )}
     </Wrapper>
   );
 }
@@ -69,27 +53,4 @@ const Wrapper = styled("div")`
   & hr {
     margin: 0.5rem 0px;
   }
-`;
-
-const QueriesWrapper = styled("div")`
-  display: flex;
-  flex-direction: column;
-
-  & > div:not(:last-of-type) {
-    padding-bottom: 0.5rem;
-    margin-bottom: 0.5rem;
-    border-bottom: 1px dotted var(--p-slate-300);
-  }
-`;
-
-const Chip = styled("span")`
-  font-size: 0.7rem;
-  font-weight: 500;
-  padding: 2px 4px;
-  background-color: var(--p-slate-200);
-  border-radius: 6px;
-  transform: translateY(-1.5px);
-  margin-left: 1ch;
-  color: var(--p-slate-700);
-  display: inline-block; // removes underline
 `;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,11 +1,11 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_KG_SOURCES_YAML: string;
   readonly VITE_GH_REPO: string;
   readonly VITE_GH_SOURCES: string;
   readonly VITE_GH_EXAMPLES_DIRECTORY: string;
   readonly VITE_TANSTACK_BASE_URL?: string;
+  readonly VITE_GH_TOKEN?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Adds a folder structure to the examples panel that matches registry:
https://github.com/frink-okn/okn-registry/tree/main/docs/registry/queries

![image](https://github.com/user-attachments/assets/3b82900a-ac51-407b-b49d-7b29d8a6e5bf)

Examples loader also now trims extra whitespace around SPARQL 48684149155eb4e21a3acdd4ec50fb4000637e52
