### PR TITLE
Improve rendering performance of query result panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "react-dom": "19.0.0",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^2.1.7",
+        "throttleit": "^2.1.0",
         "valibot": "^1.0.0"
       },
       "devDependencies": {
@@ -16039,6 +16040,18 @@
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "license": "MIT"
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-dom": "19.0.0",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^2.1.7",
+    "throttleit": "^2.1.0",
     "valibot": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
There was one big issue with the `useComunicaQuery` hook that provides results to the `Results` panel: one of the dependencies of the `useEffect` hook inside it (meant to attach events to the Comunica stream) was the `results` array itself, which changed every single time the Comunica stream updated.

What this meant in practice is that each time the Comunica stream had a `data` event, all of the event handlers were detached, and then fresh handlers were created and attached. When processing 10,000 records, that would happen 10,000 times. This created a lot of overhead.

Removing the `results` dependency and changing how results were passed to the provider (that is, removing the `immer` update and just using a plain array), rendering 10,000 rows of a generic `?s ?p ?o` SPARQL query went from taking ~60s to ~20s.

However, there's more performance to be had. For that same query, rendering all results at once when the query is completed takes ~2.5s. So, anything above that is overhead from rendering data immediately as it's added.

What I did here is a pretty easy gain-- I throttled the function updating the `result` state to 250ms. That means that `setResult` is called, *at most*, once every 250ms.

(I made a special case for the first 100 results. There, `setResult` isn't throttled, to allow initial data to show up immediately if it's available).

Doing that throttling took rendering that same query down to ~5s. That's still about a 2x overhead, but some re-rendering is necessary, and that certainly beats a 25x overhead.