### PR TITLE
remove capitalized 'FRINK' wherever it occurred

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# FRINK Query UI
+# Proto-OKN Query UI
 
-This repository contains the code for the FRINK Query UI web app, which can be used to query the Theme 1 [Proto-OKN](https://www.proto-okn.net/) knowledge graphs or the FRINK federated knowledge graph.
+This repository contains the code for the Proto-OKN Query UI web app, which can be used to query the Theme 1 [Proto-OKN](https://www.proto-okn.net/) knowledge graphs or the Proto-OKN federated knowledge graph.
 
-- **[FRINK Query UI](https://frink.apps.renci.org)**
-- [FRINK website](https://frink.renci.org/)
-- [Proto-OKN website](https://www.proto-okn.net/)
+- **[Proto-OKN Query UI](https://frink.apps.renci.org)**
+- [Proto-OKN main website](https://www.proto-okn.net/)
+- [Proto-OKN technical website](https://frink.renci.org/)
 
-![A screenshot of the FRINK Query UI](./docs/media/ui-screenshot.png)
+![A screenshot of the Proto-OKN Query UI](./docs/media/ui-screenshot.png)
 
 # Development
 

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
       }
     </style>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>FRINK</title>
+    <title>Proto-OKN SPARQL Query Service</title>
   </head>
   <body>
     <div id="root"></div>

--- a/kubernetes/Chart.yaml
+++ b/kubernetes/Chart.yaml
@@ -2,4 +2,4 @@ name: frink-ui
 apiVersion: v2
 version: 1.0.0
 type: application
-description: Frink query UI webapp.
+description: Proto-OKN query UI webapp.

--- a/src/data/sources.ts
+++ b/src/data/sources.ts
@@ -4,7 +4,7 @@ import * as v from "valibot";
 // This info isn't currently in the yaml, so it needs to be manually
 // linked here. If that changes in the future, this file can be updated.
 const federationSource = {
-  name: "FRINK Federated SPARQL",
+  name: "Proto-OKN Federated SPARQL",
   shortname: "federation",
   endpoint: "https://frink.apps.renci.org/federation/sparql",
 };

--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -7,17 +7,18 @@ export const Route = createFileRoute("/about")({
 });
 
 const content = `\
-Welcome to the FRINK query service for the NSF Prototype Open Knowledge Network (Proto-OKN). For more information, please see the following:
+Welcome to the SPARQL query service for the NSF Prototype Open Knowledge Network (Proto-OKN). For more information, please see the following:
 
-- [FRINK documentation](https://frink.renci.org)
+- [Proto-OKN technical documentation](https://frink.renci.org)
 - [NSF Proto-OKN](https://www.proto-okn.net)
-- FRINK is funded by [NSF award 2333810](https://www.nsf.gov/awardsearch/showAward?AWD_ID=2333810&HistoricalAwards=false) to [RENCI](https://renci.org)
+    - The Proto-OKN Fabric is funded by [NSF award 2535091](https://www.nsf.gov/awardsearch/showAward?AWD_ID=2535091&HistoricalAwards=false).
+    - [RENCI](https://renci.org)'s portion of the project was previously funded by [NSF award 2333810](https://www.nsf.gov/awardsearch/showAward?AWD_ID=2333810&HistoricalAwards=false).
 
-The FRINK query service is built on open source software:
+This query service is built on open source software:
 
-- [FRINK query UI](https://github.com/frink-okn/frink-query-ui/)
+- [Query UI](https://github.com/frink-okn/frink-query-ui/)
 - [Comunica](https://comunica.dev)
-- [RDF HDT](https://www.rdfhdt.org)
+- [RDF HDT](https://www.rdfhdt.org) (and an [HDT Creator](https://github.com/frink-okn/hdtc))
 - [qEndpoint CLI tools](https://github.com/the-qa-company/qEndpoint)
 - [Apache Jena](https://jena.apache.org)
 `;

--- a/src/ui/Sidebar/Sidebar.tsx
+++ b/src/ui/Sidebar/Sidebar.tsx
@@ -6,8 +6,8 @@ export function Sidebar() {
   return (
     <Nav>
       <HeaderBox>
-        <Logo>FRINK</Logo>
-        <Subtitle>Query the Proto-OKN</Subtitle>
+        <Logo>Proto-OKN</Logo>
+        <Subtitle>Query the Graphs</Subtitle>
         <Divider sx={{ my: 2 }} />
       </HeaderBox>
 


### PR DESCRIPTION
Closes #131

(Lowercase 'frink' should probably be removed when all domains and GitHub paths can be thus modified.)
