### PR TITLE
Consolidate query tabs & eliminate editor jank

### DIFF
--- a/src/context/explicitQuery.tsx
+++ b/src/context/explicitQuery.tsx
@@ -22,14 +22,14 @@ interface ExplicitQueryProviderProps {
 }
 
 export const ExplicitQueryProvider = ({ children }: ExplicitQueryProviderProps) => {
-  const [explicitQuery, setExplicityQuery] = useState<null | string>(null)
+  const [explicitQuery, setExplicitQuery] = useState<null | string>(null)
 
   return (
     <ExplicitQueryContext.Provider
       value={{
         explicitQuery: explicitQuery,
         setExplicitQuery: (query: string) => {
-          setExplicityQuery(query);
+          setExplicitQuery(query);
         },
       }}
     >

--- a/src/context/explicitQuery.tsx
+++ b/src/context/explicitQuery.tsx
@@ -1,0 +1,39 @@
+import React, { createContext, useContext, useState } from "react";
+
+const ExplicitQueryContext = createContext<{
+  explicitQuery: string | null;
+  setExplicitQuery: (query: string) => void;
+} | null>(null);
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useExplicitQueryContext = () => {
+  const context = useContext(ExplicitQueryContext);
+
+  if (context == null)
+    throw new Error(
+      "useExplicitQueryContext must be used under a ExplicitQueryProvider",
+    );
+
+  return context;
+};
+
+interface ExplicitQueryProviderProps {
+  children: React.ReactNode;
+}
+
+export const ExplicitQueryProvider = ({ children }: ExplicitQueryProviderProps) => {
+  const [explicitQuery, setExplicityQuery] = useState<null | string>(null)
+
+  return (
+    <ExplicitQueryContext.Provider
+      value={{
+        explicitQuery: explicitQuery,
+        setExplicitQuery: (query: string) => {
+          setExplicityQuery(query);
+        },
+      }}
+    >
+      {children}
+    </ExplicitQueryContext.Provider>
+  )
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -10,6 +10,7 @@ import { QueryProvider } from "../context/query";
 
 import "../styles.css";
 import { SavedQueriesProvider } from "../context/savedQueries";
+import { ExplicitQueryProvider } from "../context/explicitQuery";
 import type { QueryClient } from "@tanstack/react-query";
 import { PageWrapper } from "../ui/PageWrapper";
 
@@ -34,14 +35,16 @@ function RootComponent() {
     <CssVarsProvider>
       <QueryProvider>
         <SavedQueriesProvider>
-          <CssBaseline />
+          <ExplicitQueryProvider>
+            <CssBaseline />
 
-          <Wrapper>
-            <Sidebar />
-            <Main>
-              <Outlet />
-            </Main>
-          </Wrapper>
+            <Wrapper>
+              <Sidebar />
+              <Main>
+                <Outlet />
+              </Main>
+            </Wrapper>
+          </ExplicitQueryProvider>
         </SavedQueriesProvider>
       </QueryProvider>
     </CssVarsProvider>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,9 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { IndexPagePanels } from "../ui/Panels/layout/IndexPagePanels";
-import { Saved } from "../ui/Panels/Saved";
-import { Examples } from "../ui/Panels/Examples";
-import { Query } from "../ui/Panels/Query";
-import { Results } from "../ui/Panels/Results";
 import { styled, SvgIcon } from "@mui/joy";
 import { GitHub } from "@mui/icons-material";
 import * as v from "valibot";
@@ -73,34 +69,7 @@ export const Route = createFileRoute("/")({
 function RouteComponent() {
   return (
     <Wrapper>
-      <IndexPagePanels
-        tabs={[
-          {
-            id: "examples",
-            label: "Examples",
-            color: "var(--p-teal-400)",
-            jsx: <Examples />,
-          },
-          {
-            id: "saved",
-            label: "Saved",
-            color: "var(--p-amber-400)",
-            jsx: <Saved />,
-          },
-          {
-            id: "query",
-            label: "Query",
-            color: "var(--p-blue-400)",
-            jsx: <Query />,
-          },
-          {
-            id: "results",
-            label: "Results",
-            color: "var(--p-purple-400)",
-            jsx: <Results />,
-          },
-        ]}
-      />
+      <IndexPagePanels />
 
       <Footer>
         <AttributionText>

--- a/src/routes/term.$termId.tsx
+++ b/src/routes/term.$termId.tsx
@@ -1,11 +1,9 @@
 import { styled } from "@mui/joy";
-import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import { useWindowSize } from "@uidotdev/usehooks";
 import { TermPagePanels } from "../ui/Panels/layout/TermPagePanels";
 import { useEffect, useState } from "react";
 import { QueryEngine } from "@comunica/query-sparql";
-import { RDFTable } from "../ui/RDFTable/RDFTable";
-import { useComunicaQuery } from "../hooks/useComunicaQuery";
 import dedent from "dedent";
 
 const engine = new QueryEngine();
@@ -88,119 +86,8 @@ function RouteComponent() {
         </a>
       </header>
 
-      <TermPagePanels
-        tabs={[
-          {
-            id: "as-subject",
-            label: "As Subject",
-            color: "var(--p-orange-400)",
-            jsx: (
-              <TermPanel
-                querySparql={dedent`
-                  SELECT ?predicate ?object
-                  WHERE {
-                    <${termId}> ?predicate ?object
-                    FILTER(!isLiteral(?object))
-                  }
-                  LIMIT 50
-                `}
-              />
-            ),
-          },
-          {
-            id: "as-object",
-            label: "As Object",
-            color: "var(--p-cyan-400)",
-            jsx: (
-              <TermPanel
-                querySparql={dedent`
-                  SELECT ?subject ?predicate
-                  WHERE {
-                    ?subject ?predicate <${termId}>
-                    FILTER(!isLiteral(?subject))
-                  }
-                  LIMIT 50
-                `}
-              />
-            ),
-          },
-          {
-            id: "attributes",
-            label: "Attributes",
-            color: "var(--p-indigo-300)",
-            jsx: (
-              <TermPanel
-                querySparql={dedent`
-                  SELECT ?property ?value
-                  WHERE {
-                    <${termId}> ?property ?value
-                    FILTER(isLiteral(?value))
-                  }
-                  LIMIT 50
-                `}
-              />
-            ),
-          },
-          {
-            id: "as-predicate",
-            label: "As Predicate",
-            color: "var(--p-pink-400)",
-            jsx: (
-              <TermPanel
-                querySparql={dedent`
-                  SELECT ?subject ?object
-                  WHERE {
-                    ?subject <${termId}> ?object
-                  }
-                  LIMIT 50
-                `}
-              />
-            ),
-          },
-        ]}
-      />
+      <TermPagePanels termId={termId} />
     </Wrapper>
-  );
-}
-
-const rootRouteApi = getRouteApi("__root__");
-
-interface TermPanelProps {
-  querySparql: string;
-}
-function TermPanel({ querySparql }: TermPanelProps) {
-  const { sources } = rootRouteApi.useLoaderData();
-
-  const query = useComunicaQuery({
-    runOnMount: true,
-    query: querySparql,
-    sources: sources.filter((s) => s.shortname === "federation"),
-  });
-
-  if (query.isRunning) return <div>Loading...</div>;
-
-  return (
-    <PanelWrapper>
-      <TableHeader>
-        <Link
-          to="/"
-          search={{
-            query: querySparql.replace("LIMIT 50", "LIMIT 1000"),
-            sources: ["federation"],
-          }}
-        >
-          First 50 results, click to view full query.
-        </Link>
-      </TableHeader>
-      <TableWrapper>
-        <RDFTable
-          columns={query.columns}
-          rows={query.results}
-          wrapText={true}
-          resolveLabels={true}
-        />
-      </TableWrapper>
-    </PanelWrapper>
   );
 }
 
@@ -238,23 +125,4 @@ const Heading = styled("h1")`
     left: 0px;
     right: 0px;
   }
-`;
-
-const PanelWrapper = styled("div")`
-  --parent-padding: 0.75rem;
-  height: calc(100% + 2 * var(--parent-padding));
-  margin: calc(-1 * var(--parent-padding));
-  display: flex;
-  flex-direction: column;
-`;
-
-const TableWrapper = styled("div")`
-  flex: 1;
-  min-height: 0px;
-`;
-
-const TableHeader = styled("header")`
-  padding: 0.75rem 1rem 0rem 1rem;
-  gap: 0.5rem;
-  background-color: var(--p-slate-50);
 `;

--- a/src/ui/ExampleTree.tsx
+++ b/src/ui/ExampleTree.tsx
@@ -8,6 +8,7 @@ import {
 } from "react-aria-components";
 import { Box, styled, Tooltip } from "@mui/joy";
 import { Link } from "@tanstack/react-router";
+import { useExplicitQueryContext } from "../context/explicitQuery";
 
 export function ExampleTree({ rootNodes }: { rootNodes: ExampleNode[] }) {
   if (!rootNodes.every((node) => node.type)) return null;
@@ -58,14 +59,24 @@ const FolderItem = ({ item, isExpanded }: FolderItemProps) => (
 interface ExampleItemProps {
   item: Extract<ExampleNode, { type: "example" }>;
 }
-const ExampleItem = ({ item }: ExampleItemProps) => (
-  <Link to={"/"} search={{ query: item.query, sources: item.sources }}>
-    {item.title}
-    {item.sources.map((s) => (
-      <Chip key={s}>{s}</Chip>
-    ))}
-  </Link>
-);
+const ExampleItem = ({ item }: ExampleItemProps) => {
+  const { setExplicitQuery } = useExplicitQueryContext()
+
+  return (
+    <Link
+      to={"/"}
+      search={{ query: item.query, sources: item.sources }}
+      onClick={() => {
+        setExplicitQuery(item.query);
+      }}
+    >
+      {item.title}
+      {item.sources.map((s) => (
+        <Chip key={s}>{s}</Chip>
+      ))}
+    </Link>
+  )
+}
 
 interface ErrorItemProps {
   item: Extract<ExampleNode, { type: "error" }>;

--- a/src/ui/Panels/Query.tsx
+++ b/src/ui/Panels/Query.tsx
@@ -81,7 +81,7 @@ export function Query() {
       <LabelContainer className="query">
         <h3>SPARQL Query</h3>
         <YasqeEditor
-          value={fastUpdatingSparql}
+          initialValue={fastUpdatingSparql}
           onChange={(newValue, isSyntaxValid) => {
             setFastUpdatingSparql(newValue);
             setIsSparqlValid(isSyntaxValid);

--- a/src/ui/Panels/layout/IndexPagePanels.tsx
+++ b/src/ui/Panels/layout/IndexPagePanels.tsx
@@ -12,13 +12,11 @@ import { Panel } from "./Panel";
 import { TabsPanel } from "./TabsPanel";
 import { styled } from "@mui/joy";
 import { useEffect, useState } from "react";
-import { getRouteApi } from "@tanstack/react-router";
-
-const indexRouteApi = getRouteApi("/");
+import { useExplicitQueryContext } from "../../../context/explicitQuery";
 
 export function IndexPagePanels() {
   const { width } = useWindowSize();
-  const search = indexRouteApi.useSearch()
+  const { explicitQuery } = useExplicitQueryContext()
 
   const queryTabs = {
     query: {
@@ -43,10 +41,10 @@ export function IndexPagePanels() {
   // When the query has changed (e.g. by selecting an example query), switch
   // to the query tab.
   useEffect(() => {
-    if (selectedQueryTab !== "query") {
+    if (explicitQuery && selectedQueryTab !== "query") {
       setSelectedQueryTab("query")
     }
-  }, [search.query])
+  }, [explicitQuery])
 
   const resultsTabs = {
     results: {

--- a/src/ui/Panels/layout/IndexPagePanels.tsx
+++ b/src/ui/Panels/layout/IndexPagePanels.tsx
@@ -44,7 +44,7 @@ export function IndexPagePanels() {
     if (explicitQuery && selectedQueryTab !== "query") {
       setSelectedQueryTab("query")
     }
-  }, [explicitQuery])
+  }, [explicitQuery, selectedQueryTab])
 
   const resultsTabs = {
     results: {

--- a/src/ui/Panels/layout/IndexPagePanels.tsx
+++ b/src/ui/Panels/layout/IndexPagePanels.tsx
@@ -4,21 +4,57 @@ import {
   Panel as ResizablePanel,
   PanelResizeHandle,
 } from "react-resizable-panels";
+import { Saved } from "../Saved";
+import { Examples } from "../Examples";
+import { Query } from "../Query";
+import { Results } from "../Results";
 import { Panel } from "./Panel";
 import { TabsPanel } from "./TabsPanel";
 import { styled } from "@mui/joy";
+import { useEffect, useState } from "react";
+import { getRouteApi } from "@tanstack/react-router";
 
-interface PanelsProps {
-  tabs: {
-    id: string;
-    label: string;
-    color: string;
-    jsx: React.ReactElement;
-  }[];
-}
+const indexRouteApi = getRouteApi("/");
 
-export function IndexPagePanels({ tabs }: PanelsProps) {
+export function IndexPagePanels() {
   const { width } = useWindowSize();
+  const search = indexRouteApi.useSearch()
+
+  const queryTabs = {
+    query: {
+      label: "Query",
+      color: "var(--p-blue-400)",
+      jsx: <Query />,
+    },
+    examples: {
+      label: "Examples",
+      color: "var(--p-teal-400)",
+      jsx: <Examples />,
+    },
+    saved: {
+      label: "Saved",
+      color: "var(--p-amber-400)",
+      jsx: <Saved />,
+    },
+  };
+
+  const [selectedQueryTab, setSelectedQueryTab] = useState("query");
+
+  // When the query has changed (e.g. by selecting an example query), switch
+  // to the query tab.
+  useEffect(() => {
+    if (selectedQueryTab !== "query") {
+      setSelectedQueryTab("query")
+    }
+  }, [search.query])
+
+  const resultsTabs = {
+    results: {
+      label: "Results",
+      color: "var(--p-purple-400)",
+      jsx: <Results />,
+    },
+  };
 
   if (!width) return null;
 
@@ -29,38 +65,31 @@ export function IndexPagePanels({ tabs }: PanelsProps) {
         direction="horizontal"
       >
         <ResizablePanel defaultSize={50} minSize={10} collapsible={true}>
-          <PanelGroup
-            direction="vertical"
-            autoSaveId="localstorage-panels-vert"
-          >
-            <ResizablePanel defaultSize={60} minSize={10} order={1}>
-              <Panel tab={tabs.filter((t) => t.id === "query")[0]} />
-            </ResizablePanel>
-
-            <Handle horizontal={"true"} />
-
-            <ResizablePanel
-              defaultSize={40}
-              minSize={10}
-              order={2}
-              collapsible={true}
-            >
-              <TabsPanel
-                tabs={tabs.filter((t) => ["examples", "saved"].includes(t.id))}
-              />
-            </ResizablePanel>
-          </PanelGroup>
+          <TabsPanel
+            tabs={queryTabs}
+            selectedTab={selectedQueryTab}
+            handleTabSelect={(tabId) => setSelectedQueryTab(tabId)}
+          />
         </ResizablePanel>
 
         <Handle horizontal={"false"} />
 
         <ResizablePanel defaultSize={50} minSize={10} collapsible={true}>
-          <Panel tab={tabs.filter((t) => t.id === "results")[0]} />
+          <Panel tab={resultsTabs.results} />
         </ResizablePanel>
       </WrapperPanelGroup>
     );
 
-  return <TabsPanel tabs={tabs} />;
+  return (
+    <TabsPanel
+      tabs={{
+        ...queryTabs,
+        ...resultsTabs,
+      }}
+      selectedTab={selectedQueryTab}
+      handleTabSelect={(tabId) => setSelectedQueryTab(tabId)}
+    />
+  );
 }
 
 const WrapperPanelGroup = styled(PanelGroup)`

--- a/src/ui/Panels/layout/Panel.tsx
+++ b/src/ui/Panels/layout/Panel.tsx
@@ -1,12 +1,8 @@
 import { styled } from "@mui/joy";
+import { Tab } from "./TabsPanel"
 
 interface PanelProps {
-  tab: {
-    id: string;
-    label: string;
-    color: string;
-    jsx: React.ReactElement;
-  };
+  tab: Tab
 }
 
 export function Panel({ tab: { color, label, jsx } }: PanelProps) {

--- a/src/ui/Panels/layout/TabsPanel.tsx
+++ b/src/ui/Panels/layout/TabsPanel.tsx
@@ -1,49 +1,59 @@
 import { styled } from "@mui/joy";
-import React, { useState } from "react";
+import React from "react";
 
-type Tab = {
-  id: string;
+export type Tab = {
   label: string;
   color: string;
   jsx: React.ReactElement;
 };
+
 interface TabsPanelProps {
-  tabs: Tab[];
+  tabs: Record<string, Tab>;
+  selectedTab: string;
+  handleTabSelect: (tabId: string) => void;
 }
 
-export function TabsPanel({ tabs }: TabsPanelProps) {
-  const [selectedTab, setSelectedTab] = useState<Tab>(tabs[0]);
+export function TabsPanel({
+  tabs,
+  selectedTab,
+  handleTabSelect,
+}: TabsPanelProps) {
+  const _selectedTab = tabs[selectedTab];
+
+  if (!_selectedTab) {
+    throw new Error(`Tab ${selectedTab} is not a defined tab.`);
+  }
 
   return (
     <Panel
-      style={{ "--accent-color": selectedTab.color } as React.CSSProperties}
+      style={{ "--accent-color": _selectedTab.color } as React.CSSProperties}
     >
       <header>
-        {tabs.map((tab) => (
+        {Object.entries(tabs).map(([tabId, tab]) => (
           <Tab
-            key={tab.id}
+            key={tabId}
             tabIndex={0}
             role="button"
             style={
               { "--button-accent-color": tab.color } as React.CSSProperties
             }
-            className={tab.id === selectedTab.id ? "selected" : undefined}
+            className={tabId === selectedTab ? "selected" : undefined}
             onClick={() => {
-              setSelectedTab(tabs.filter((t) => t.id === tab.id)[0]);
+              handleTabSelect(tabId);
             }}
             onKeyDown={(e) => {
-              if (e.key === " " || e.key === "Enter")
-                setSelectedTab(tabs.filter((t) => t.id === tab.id)[0]);
+              if (e.key === " " || e.key === "Enter") handleTabSelect(tabId);
             }}
           >
             <h2>{tab.label}</h2>
           </Tab>
         ))}
       </header>
-      {tabs.map((tab) => (
+
+      {Object.entries(tabs).map(([tabId, tab]) => (
         <Content
-          key={tab.id}
-          style={{ display: selectedTab.id === tab.id ? "block" : "none" }}
+          key={tabId}
+          style={{ display: selectedTab === tabId ? "block" : "none" }}
         >
           {tab.jsx}
         </Content>

--- a/src/ui/Panels/layout/TermPagePanels.tsx
+++ b/src/ui/Panels/layout/TermPagePanels.tsx
@@ -135,7 +135,7 @@ const WrapperPanelGroup = styled(PanelGroup)`
 interface HandleProps {
   horizontal: string;
 }
-const Handle = styled(PanelResizeHandle) <HandleProps>`
+const Handle = styled(PanelResizeHandle)<HandleProps>`
   align-self: center;
   width: 12px;
   border-radius: 6px;

--- a/src/ui/Panels/layout/TermPagePanels.tsx
+++ b/src/ui/Panels/layout/TermPagePanels.tsx
@@ -7,20 +7,92 @@ import {
 import { Panel } from "./Panel";
 import { TabsPanel } from "./TabsPanel";
 import { styled } from "@mui/joy";
+import { useState } from "react";
+import dedent from "dedent";
+import { TermPanel } from "./TermPanel";
 
-interface PanelsProps {
-  tabs: {
-    id: string;
-    label: string;
-    color: string;
-    jsx: React.ReactElement;
-  }[];
+interface TermPagePanelsProps {
+  termId: string;
 }
 
-export function TermPagePanels({ tabs }: PanelsProps) {
+export function TermPagePanels({ termId }: TermPagePanelsProps) {
   const { width } = useWindowSize();
 
+  const [selectedTab, setSelectedTab] = useState("as-subject")
+
   if (!width) return null;
+
+
+  const relationsTabs = {
+    "as-subject": {
+      label: "As Subject",
+      color: "var(--p-orange-400)",
+      jsx: (
+        <TermPanel
+          querySparql={dedent`
+            SELECT ?predicate ?object
+            WHERE {
+              <${termId}> ?predicate ?object
+              FILTER(!isLiteral(?object))
+            }
+            LIMIT 50
+          `}
+        />
+      ),
+    },
+
+    "as-object": {
+      label: "As Object",
+      color: "var(--p-cyan-400)",
+      jsx: (
+        <TermPanel
+          querySparql={dedent`
+            SELECT ?subject ?predicate
+            WHERE {
+              ?subject ?predicate <${termId}>
+              FILTER(!isLiteral(?subject))
+            }
+            LIMIT 50
+          `}
+        />
+      ),
+    },
+
+    "as-predicate": {
+      label: "As Predicate",
+      color: "var(--p-pink-400)",
+      jsx: (
+        <TermPanel
+          querySparql={dedent`
+            SELECT ?subject ?object
+            WHERE {
+              ?subject <${termId}> ?object
+            }
+            LIMIT 50
+          `}
+        />
+      ),
+    },
+  };
+
+  const attributesTabs = {
+    attributes: {
+      label: "Attributes",
+      color: "var(--p-indigo-300)",
+      jsx: (
+        <TermPanel
+          querySparql={dedent`
+            SELECT ?property ?value
+            WHERE {
+              <${termId}> ?property ?value
+              FILTER(isLiteral(?value))
+            }
+            LIMIT 50
+          `}
+        />
+      ),
+    },
+  };
 
   if (width > 700)
     return (
@@ -29,22 +101,31 @@ export function TermPagePanels({ tabs }: PanelsProps) {
         direction="vertical"
       >
         <ResizablePanel defaultSize={30} minSize={10} collapsible={true}>
-          <Panel tab={tabs.filter((t) => t.id === "attributes")[0]} />
+          <Panel tab={attributesTabs.attributes} />
         </ResizablePanel>
 
         <Handle horizontal={"true"} />
 
         <ResizablePanel defaultSize={80} minSize={10} collapsible={true}>
           <TabsPanel
-            tabs={tabs.filter((t) =>
-              ["as-subject", "as-predicate", "as-object"].includes(t.id),
-            )}
+            tabs={relationsTabs}
+            selectedTab={selectedTab}
+            handleTabSelect={(tabId) => setSelectedTab(tabId)}
           />
         </ResizablePanel>
       </WrapperPanelGroup>
     );
 
-  return <TabsPanel tabs={tabs} />;
+  return (
+    <TabsPanel
+      tabs={{
+        ...attributesTabs,
+        ...relationsTabs,
+      }}
+      selectedTab={selectedTab}
+      handleTabSelect={(tabId) => setSelectedTab(tabId)}
+    />
+  );
 }
 
 const WrapperPanelGroup = styled(PanelGroup)`

--- a/src/ui/Panels/layout/TermPagePanels.tsx
+++ b/src/ui/Panels/layout/TermPagePanels.tsx
@@ -7,7 +7,7 @@ import {
 import { Panel } from "./Panel";
 import { TabsPanel } from "./TabsPanel";
 import { styled } from "@mui/joy";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import dedent from "dedent";
 import { TermPanel } from "./TermPanel";
 
@@ -20,10 +20,7 @@ export function TermPagePanels({ termId }: TermPagePanelsProps) {
 
   const [selectedTab, setSelectedTab] = useState("as-subject")
 
-  if (!width) return null;
-
-
-  const relationsTabs = {
+  const relationsTabs = useMemo(() => ({
     "as-subject": {
       label: "As Subject",
       color: "var(--p-orange-400)",
@@ -73,9 +70,9 @@ export function TermPagePanels({ termId }: TermPagePanelsProps) {
         />
       ),
     },
-  };
+  }), [termId]);
 
-  const attributesTabs = {
+  const attributesTabs = useMemo(() => ({
     attributes: {
       label: "Attributes",
       color: "var(--p-indigo-300)",
@@ -92,7 +89,9 @@ export function TermPagePanels({ termId }: TermPagePanelsProps) {
         />
       ),
     },
-  };
+  }), [termId]);
+
+  if (!width) return null;
 
   if (width > 700)
     return (
@@ -136,7 +135,7 @@ const WrapperPanelGroup = styled(PanelGroup)`
 interface HandleProps {
   horizontal: string;
 }
-const Handle = styled(PanelResizeHandle)<HandleProps>`
+const Handle = styled(PanelResizeHandle) <HandleProps>`
   align-self: center;
   width: 12px;
   border-radius: 6px;

--- a/src/ui/Panels/layout/TermPanel.tsx
+++ b/src/ui/Panels/layout/TermPanel.tsx
@@ -1,0 +1,66 @@
+import { styled } from "@mui/joy";
+import { getRouteApi, Link } from "@tanstack/react-router";
+import { useComunicaQuery } from "../../../hooks/useComunicaQuery";
+import { RDFTable } from "../../RDFTable/RDFTable"
+
+interface TermPanelProps {
+  querySparql: string;
+}
+
+const rootRouteApi = getRouteApi("__root__");
+
+export function TermPanel({ querySparql }: TermPanelProps) {
+  const { sources } = rootRouteApi.useLoaderData();
+
+  const query = useComunicaQuery({
+    runOnMount: true,
+    query: querySparql,
+    sources: sources.filter((s) => s.shortname === "federation"),
+  });
+
+  if (query.isRunning) return <div>Loading...</div>;
+
+  return (
+    <PanelWrapper>
+      <TableHeader>
+        <Link
+          to="/"
+          search={{
+            query: querySparql.replace("LIMIT 50", "LIMIT 1000"),
+            sources: ["federation"],
+          }}
+        >
+          First 50 results, click to view full query.
+        </Link>
+      </TableHeader>
+      <TableWrapper>
+        <RDFTable
+          columns={query.columns}
+          rows={query.results}
+          wrapText={true}
+          resolveLabels={true}
+        />
+      </TableWrapper>
+    </PanelWrapper>
+  );
+}
+
+
+const PanelWrapper = styled("div")`
+  --parent-padding: 0.75rem;
+  height: calc(100% + 2 * var(--parent-padding));
+  margin: calc(-1 * var(--parent-padding));
+  display: flex;
+  flex-direction: column;
+`;
+
+const TableWrapper = styled("div")`
+  flex: 1;
+  min-height: 0px;
+`;
+
+const TableHeader = styled("header")`
+  padding: 0.75rem 1rem 0rem 1rem;
+  gap: 0.5rem;
+  background-color: var(--p-slate-50);
+`;

--- a/src/ui/YasqeEditor.tsx
+++ b/src/ui/YasqeEditor.tsx
@@ -37,9 +37,15 @@ export function YasqeEditor({ initialValue, onChange }: YasqeEditorProps) {
   }, []);
 
   useEffect(() => {
-    if (explicitQuery !== null && yasqeInstance.current) {
-      yasqeInstance.current.setValue(explicitQuery)
-      yasqeInstance.current.refresh()
+    const editor = yasqeInstance.current;
+
+    if (explicitQuery === null || !editor) {
+      return;
+    }
+
+    if (editor.getValue() !== explicitQuery) {
+      editor.setValue(explicitQuery)
+      editor.refresh()
     }
   }, [explicitQuery])
 

--- a/src/ui/YasqeEditor.tsx
+++ b/src/ui/YasqeEditor.tsx
@@ -1,15 +1,17 @@
 import { styled } from "@mui/joy";
 import Yasqe from "@triply/yasqe";
 import { useRef, useEffect } from "react";
+import { useExplicitQueryContext } from "../context/explicitQuery";
 
 interface YasqeEditorProps {
-  value: string;
+  initialValue: string;
   onChange: (newValue: string, isSyntaxValid: boolean) => void;
 }
 
-export function YasqeEditor({ value, onChange }: YasqeEditorProps) {
+export function YasqeEditor({ initialValue, onChange }: YasqeEditorProps) {
   const divEl = useRef(null);
   const yasqeInstance = useRef<Yasqe | null>(null);
+  const { explicitQuery } = useExplicitQueryContext()
 
   useEffect(() => {
     if (!divEl.current) {
@@ -17,7 +19,13 @@ export function YasqeEditor({ value, onChange }: YasqeEditorProps) {
       return;
     }
 
-    yasqeInstance.current = new Yasqe(divEl.current);
+    yasqeInstance.current = new Yasqe(divEl.current, {
+      value: initialValue,
+      consumeShareLink: null,
+      persistenceId: null,
+    });
+
+    // yasqeInstance.current.setValue(initialValue)
 
     return () => {
       yasqeInstance.current?.destroy();
@@ -26,10 +34,11 @@ export function YasqeEditor({ value, onChange }: YasqeEditorProps) {
   }, []);
 
   useEffect(() => {
-    if (yasqeInstance.current && yasqeInstance.current.getValue() !== value) {
-      yasqeInstance.current.setValue(value);
+    if (explicitQuery !== null && yasqeInstance.current) {
+      yasqeInstance.current.setValue(explicitQuery)
+      yasqeInstance.current.refresh()
     }
-  }, [value]);
+  }, [explicitQuery])
 
   useEffect(() => {
     const handleChange = () => {

--- a/src/ui/YasqeEditor.tsx
+++ b/src/ui/YasqeEditor.tsx
@@ -13,6 +13,9 @@ export function YasqeEditor({ initialValue, onChange }: YasqeEditorProps) {
   const yasqeInstance = useRef<Yasqe | null>(null);
   const { explicitQuery } = useExplicitQueryContext()
 
+  // Capture the initial value of the editor exactly once, on mount
+  const initialValueRef = useRef(initialValue)
+
   useEffect(() => {
     if (!divEl.current) {
       console.error("divEl.current is null in YasqeEditor");
@@ -20,12 +23,12 @@ export function YasqeEditor({ initialValue, onChange }: YasqeEditorProps) {
     }
 
     yasqeInstance.current = new Yasqe(divEl.current, {
-      value: initialValue,
       consumeShareLink: null,
       persistenceId: null,
     });
 
-    // yasqeInstance.current.setValue(initialValue)
+    yasqeInstance.current.setValue(initialValueRef.current);
+    yasqeInstance.current.refresh()
 
     return () => {
       yasqeInstance.current?.destroy();


### PR DESCRIPTION
Consolidating the query tabs (putting "Examples" and "Saved" next to "Query") turned out to be deceptively tricky because of how state management was set up. There's a lot of info in the individual commits (I recommend reading them individually), but I will summarize here:

* Refactors the `TabsPanel` component to accept the selected tab as a prop instead of managing it internally
* Adds a way to explicitly set a query (i.e. programmatically set it, to differentiate from the `query` parameter in the URL bar changing)
* Removes `Yasqe`'s built-in persistence/hydration mechanism, which was occasionally stepping on our own functionality
* Removes the URL query parameters as the Yasqe editor's source of truth, except on initial mount.

As a result:
* Typing into the editor is a lot smoother
* It no longer happens that the cursor sometimes jumps to the beginning of the editor
* Clicking on an example query switches to the query tab