### PR TITLE
Fix tabs jumping back to Query after loading an example

### DIFF
--- a/src/ui/Panels/layout/IndexPagePanels.tsx
+++ b/src/ui/Panels/layout/IndexPagePanels.tsx
@@ -39,12 +39,13 @@ export function IndexPagePanels() {
   const [selectedQueryTab, setSelectedQueryTab] = useState("query");
 
   // When the query has changed (e.g. by selecting an example query), switch
-  // to the query tab.
+  // to the query tab. Depending only on explicitQuery ensures this fires on
+  // example selection but not when the user manually switches tabs afterward.
   useEffect(() => {
-    if (explicitQuery && selectedQueryTab !== "query") {
+    if (explicitQuery) {
       setSelectedQueryTab("query")
     }
-  }, [explicitQuery, selectedQueryTab])
+  }, [explicitQuery])
 
   const resultsTabs = {
     results: {


### PR DESCRIPTION
The effect that switches to the Query tab when an example is selected depended on selectedQueryTab, so it re-fired whenever the user manually switched tabs — snapping them back to Query because explicitQuery was still set from the prior example click.