### PR TITLE
Fix logo image path when deployed under a subpath

### DIFF
--- a/src/ui/Sidebar/Sidebar.tsx
+++ b/src/ui/Sidebar/Sidebar.tsx
@@ -7,7 +7,7 @@ export function Sidebar() {
   return (
     <Nav>
       <HeaderBox>
-        <a target="_blank" href="https://proto-okn.net/"><LogoImage src="/Purple-no-background-300x200.png"></LogoImage></a>
+        <a target="_blank" href="https://proto-okn.net/"><LogoImage src={`${import.meta.env.BASE_URL}Purple-no-background-300x200.png`}></LogoImage></a>
         <Logo><InvisibleA target="_blank" href="https://proto-okn.net/">Proto-OKN</InvisibleA></Logo>
         <Subtitle><InvisibleLink to={"/"}>Query the Graphs</InvisibleLink></Subtitle>
         <Divider sx={{ my: 2 }} />


### PR DESCRIPTION
The sidebar logo used an absolute path, which broke on subpath deploys (e.g. GitHub Pages). Prefix with import.meta.env.BASE_URL so Vite resolves it against the configured base.